### PR TITLE
fix(cli): fix npx create new app

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,4 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.18.0"
+  "version": "0.18.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17554,16 +17554,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/magicast": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.4.tgz",
-      "integrity": "sha512-TyDF/Pn36bBji9rWKHlZe+PZb6Mx5V8IHCSxk7X4aljM4e/vyDvZZYwHewdVaqiA0nb3ghfHU/6AUpDxWoER2Q==",
-      "dependencies": {
-        "@babel/parser": "^7.24.4",
-        "@babel/types": "^7.24.0",
-        "source-map-js": "^1.2.0"
-      }
-    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -27145,7 +27135,7 @@
     },
     "packages/cli": {
       "name": "@tinijs/cli",
-      "version": "0.18.0",
+      "version": "0.18.2",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/slugify": "^2.2.1",

--- a/packages/cli/cli/utils/cli.ts
+++ b/packages/cli/cli/utils/cli.ts
@@ -132,9 +132,7 @@ export function createCLICommand<
   ) => Promisable<void>;
 }
 
-export async function setupCLIExpansion<
-  Options extends Record<string, unknown> = {},
->(tiniProject: TiniProject) {
+export async function setupCLIExpansion(tiniProject: TiniProject) {
   const {expand: cliExpand = [], noAutoExpansions} =
     tiniProject.config.cli || {};
   // auto load available expansions

--- a/packages/cli/cli/utils/project.ts
+++ b/packages/cli/cli/utils/project.ts
@@ -1,18 +1,23 @@
-import {resolve} from 'pathe';
+import {resolve, parse} from 'pathe';
+import {fileURLToPath} from 'node:url';
 import type {PackageJson} from 'type-fest';
-import {readJSON} from 'fs-extra/esm';
+import {readJSON, pathExistsSync} from 'fs-extra/esm';
 
 import {modifyJSONFile} from './modify.js';
-import cliPackageJSON = require('../../package.json');
 
 export const TINIJS_INSTALL_DIR_PATH = resolve('node_modules', '@tinijs');
 
 export async function loadCLIPackageJSON() {
-  return cliPackageJSON as PackageJson;
+  const path = resolve(
+    parse(fileURLToPath(import.meta.url)).dir,
+    '../../../package.json'
+  );
+  return (!pathExistsSync(path) ? {} : readJSON(path)) as Promise<PackageJson>;
 }
 
 export async function loadProjectPackageJSON() {
-  return readJSON(resolve('package.json')) as Promise<PackageJson>;
+  const path = resolve('package.json');
+  return (!pathExistsSync(path) ? {} : readJSON(path)) as Promise<PackageJson>;
 }
 
 export async function modifyProjectPackageJSON(

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinijs/cli",
-  "version": "0.18.0",
+  "version": "0.18.2",
   "description": "The CLI for the TiniJS framework and beyond.",
   "author": "Nhan Lam",
   "homepage": "https://tinijs.dev",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,8 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "dist",
-    "resolveJsonModule": true
+    "outDir": "dist"
   },
   "include": [
     "**/*"


### PR DESCRIPTION
- Fix bug when create a new app using `npx`. The CLI trying to read a package.json in the current location to check if there is autoload expansions available, but there is none outside a project.