### PR TITLE
fix: remove Angular-alike syntax

### DIFF
--- a/apps/benchmark.tinijs.dev/app/app.ts
+++ b/apps/benchmark.tinijs.dev/app/app.ts
@@ -1,7 +1,7 @@
 import {html} from 'lit';
 
 import {
-  App,
+  app,
   TiniComponent,
   registerConfig,
   type AppWithConfig,
@@ -20,7 +20,7 @@ import {globalStyles, shareStyles} from './styles.js';
 
 import './layouts/default.js';
 
-@App({providers})
+@app({providers})
 export class AppRoot
   extends TiniComponent
   implements AppWithConfig<AppConfig>, AppWithRouter, AppWithMeta, AppWithUI

--- a/apps/benchmark.tinijs.dev/app/layouts/default.ts
+++ b/apps/benchmark.tinijs.dev/app/layouts/default.ts
@@ -1,8 +1,8 @@
 import {html} from 'lit';
 
-import {Layout, TiniComponent} from '@tinijs/core';
+import {layout, TiniComponent} from '@tinijs/core';
 
-@Layout({
+@layout({
   name: 'app-layout-default',
 })
 export class AppLayoutDefault extends TiniComponent {

--- a/apps/benchmark.tinijs.dev/app/pages/404.ts
+++ b/apps/benchmark.tinijs.dev/app/pages/404.ts
@@ -1,9 +1,9 @@
 import {html} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 import type {PageWithMetadata, PageMetadata} from '@tinijs/meta';
 
-@Page({
+@page({
   name: 'app-page-404',
 })
 export class AppPage404 extends TiniComponent implements PageWithMetadata {

--- a/apps/benchmark.tinijs.dev/app/pages/home.ts
+++ b/apps/benchmark.tinijs.dev/app/pages/home.ts
@@ -1,10 +1,10 @@
 import {html} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 
 import SUBJECTS from '../subjects.js';
 
-@Page({
+@page({
   name: 'app-page-home',
 })
 export class AppPageHome extends TiniComponent {

--- a/apps/benchmark.tinijs.dev/app/pages/subjects/hello-world.ts
+++ b/apps/benchmark.tinijs.dev/app/pages/subjects/hello-world.ts
@@ -1,8 +1,8 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 
-@Page({
+@page({
   name: 'app-page-hello-world',
 })
 export class AppPageHelloWorld extends TiniComponent {

--- a/apps/benchmark.tinijs.dev/app/pages/subjects/ui-box.ts
+++ b/apps/benchmark.tinijs.dev/app/pages/subjects/ui-box.ts
@@ -1,8 +1,8 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 import type {PageWithMetadata} from '@tinijs/meta';
-import {UseQuery} from '@tinijs/router';
+import {useSearchParams} from '@tinijs/router';
 
 import {TiniBoxComponent} from '../../ui/components/box.js';
 
@@ -174,7 +174,7 @@ const CONTAINER_PROPS = {
   cursor: 'auto',
 };
 
-@Page({
+@page({
   name: 'app-page-ui-box',
   components: [TiniBoxComponent],
 })
@@ -184,11 +184,11 @@ export class AppPageUIBox extends TiniComponent implements PageWithMetadata {
     description: 'The tini-box component.',
   };
 
-  @UseQuery() readonly query!: {items?: number};
+  @useSearchParams() readonly searchParams!: {items?: number};
 
   protected render() {
     return repeat(
-      Number(this.query.items || 1),
+      Number(this.searchParams.items || 1),
       i => html`
         <tini-box
           display="inline"

--- a/apps/benchmark.tinijs.dev/app/pages/subjects/ui-container.ts
+++ b/apps/benchmark.tinijs.dev/app/pages/subjects/ui-container.ts
@@ -1,8 +1,8 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 import type {PageWithMetadata} from '@tinijs/meta';
-import {UseQuery} from '@tinijs/router';
+import {useSearchParams} from '@tinijs/router';
 
 import {TiniContainerComponent} from '../../ui/components/container.js';
 
@@ -156,7 +156,7 @@ const CONTAINER_PROPS = {
   cursor: 'auto',
 };
 
-@Page({
+@page({
   name: 'app-page-ui-container',
   components: [TiniContainerComponent],
 })
@@ -169,11 +169,11 @@ export class AppPageUIContainer
     description: 'The tini-container component.',
   };
 
-  @UseQuery() readonly query!: {items?: number};
+  @useSearchParams() readonly searchParams!: {items?: number};
 
   protected render() {
     return repeat(
-      Number(this.query.items || 1),
+      Number(this.searchParams.items || 1),
       i => html`
         <tini-container
           display="initial"

--- a/apps/benchmark.tinijs.dev/app/pages/subjects/ui-flex.ts
+++ b/apps/benchmark.tinijs.dev/app/pages/subjects/ui-flex.ts
@@ -1,8 +1,8 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 import type {PageWithMetadata} from '@tinijs/meta';
-import {UseQuery} from '@tinijs/router';
+import {useSearchParams} from '@tinijs/router';
 
 import {TiniFlexComponent} from '../../ui/components/flex.js';
 
@@ -176,7 +176,7 @@ const CONTAINER_PROPS = {
   cursor: 'auto',
 };
 
-@Page({
+@page({
   name: 'app-page-ui-flex',
   components: [TiniFlexComponent],
 })
@@ -186,11 +186,11 @@ export class AppPageUIFlex extends TiniComponent implements PageWithMetadata {
     description: 'The tini-flex component.',
   };
 
-  @UseQuery() readonly query!: {items?: number};
+  @useSearchParams() readonly searchParams!: {items?: number};
 
   protected render() {
     return repeat(
-      Number(this.query.items || 1),
+      Number(this.searchParams.items || 1),
       i => html`
         <tini-flex
           display="flex"

--- a/apps/benchmark.tinijs.dev/app/pages/subjects/ui-grid.ts
+++ b/apps/benchmark.tinijs.dev/app/pages/subjects/ui-grid.ts
@@ -1,8 +1,8 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 import type {PageWithMetadata} from '@tinijs/meta';
-import {UseQuery} from '@tinijs/router';
+import {useSearchParams} from '@tinijs/router';
 
 import {TiniGridComponent} from '../../ui/components/grid.js';
 
@@ -184,7 +184,7 @@ const CONTAINER_PROPS = {
   cursor: 'auto',
 };
 
-@Page({
+@page({
   name: 'app-page-ui-grid',
   components: [TiniGridComponent],
 })
@@ -194,11 +194,11 @@ export class AppPageUIGrid extends TiniComponent implements PageWithMetadata {
     description: 'The tini-grid component.',
   };
 
-  @UseQuery() readonly query!: {items?: number};
+  @useSearchParams() readonly searchParams!: {items?: number};
 
   protected render() {
     return repeat(
-      Number(this.query.items || 1),
+      Number(this.searchParams.items || 1),
       i => html`
         <tini-grid
           display="grid"

--- a/apps/benchmark.tinijs.dev/app/pages/subjects/ui-heading.ts
+++ b/apps/benchmark.tinijs.dev/app/pages/subjects/ui-heading.ts
@@ -1,8 +1,8 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 import type {PageWithMetadata} from '@tinijs/meta';
-import {UseQuery} from '@tinijs/router';
+import {useSearchParams} from '@tinijs/router';
 
 import {TiniHeadingComponent} from '../../ui/components/heading.js';
 
@@ -10,7 +10,7 @@ import {repeat} from '../../utils/subject.js';
 
 import {HEADING_SUBJECT} from '../../subjects.js';
 
-@Page({
+@page({
   name: 'app-page-ui-heading',
   components: [TiniHeadingComponent],
 })
@@ -23,11 +23,11 @@ export class AppPageUIHeading
     description: 'The tini-heading component.',
   };
 
-  @UseQuery() readonly query!: {items?: number};
+  @useSearchParams() readonly searchParams!: {items?: number};
 
   protected render() {
     return repeat(
-      Number(this.query.items || 1),
+      Number(this.searchParams.items || 1),
       i => html`
         <tini-heading>Heading level 1 (#${i})</tini-heading>
         <tini-heading italic level="2"

--- a/apps/benchmark.tinijs.dev/app/pages/subjects/ui-image.ts
+++ b/apps/benchmark.tinijs.dev/app/pages/subjects/ui-image.ts
@@ -1,8 +1,8 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 import type {PageWithMetadata} from '@tinijs/meta';
-import {UseQuery} from '@tinijs/router';
+import {useSearchParams} from '@tinijs/router';
 
 import {TiniImageComponent} from '../../ui/components/image.js';
 
@@ -17,7 +17,7 @@ const PNG = new URL('../../assets/placeholders/image.png', import.meta.url)
 const SVG = new URL('../../assets/placeholders/image.svg', import.meta.url)
   .href;
 
-@Page({
+@page({
   name: 'app-page-ui-image',
   components: [TiniImageComponent],
 })
@@ -27,11 +27,11 @@ export class AppPageUIImage extends TiniComponent implements PageWithMetadata {
     description: 'The tini-image component.',
   };
 
-  @UseQuery() readonly query!: {items?: number};
+  @useSearchParams() readonly searchParams!: {items?: number};
 
   protected render() {
     return repeat(
-      Number(this.query.items || 1),
+      Number(this.searchParams.items || 1),
       () => html`
         <tini-image src=${SVG} alt="Placeholder"></tini-image>
         <tini-image src=${JPG} width="350px" alt="Placeholder"></tini-image>

--- a/apps/benchmark.tinijs.dev/app/pages/subjects/ui-link.ts
+++ b/apps/benchmark.tinijs.dev/app/pages/subjects/ui-link.ts
@@ -1,8 +1,8 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 import type {PageWithMetadata} from '@tinijs/meta';
-import {UseQuery} from '@tinijs/router';
+import {useSearchParams} from '@tinijs/router';
 
 import {TiniLinkComponent} from '../../ui/components/link.js';
 
@@ -10,7 +10,7 @@ import {repeat} from '../../utils/subject.js';
 
 import {LINK_SUBJECT} from '../../subjects.js';
 
-@Page({
+@page({
   name: 'app-page-ui-link',
   components: [TiniLinkComponent],
 })
@@ -20,11 +20,11 @@ export class AppPageUILink extends TiniComponent implements PageWithMetadata {
     description: 'The tini-link component.',
   };
 
-  @UseQuery() readonly query!: {items?: number};
+  @useSearchParams() readonly searchParams!: {items?: number};
 
   protected render() {
     return repeat(
-      Number(this.query.items || 1),
+      Number(this.searchParams.items || 1),
       i => html`
         <tini-link href="#">Link (#${i})</tini-link>
         <tini-link href="#" disabled>Disabled link (#${i})</tini-link>

--- a/apps/benchmark.tinijs.dev/app/pages/subjects/ui-text-native.ts
+++ b/apps/benchmark.tinijs.dev/app/pages/subjects/ui-text-native.ts
@@ -1,14 +1,14 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 import type {PageWithMetadata} from '@tinijs/meta';
-import {UseQuery} from '@tinijs/router';
+import {useSearchParams} from '@tinijs/router';
 
 import {repeat} from '../../utils/subject.js';
 
 import {TEXT_NATIVE_SUBJECT} from '../../subjects.js';
 
-@Page({
+@page({
   name: 'app-page-ui-text-native',
 })
 export class AppPageUITextNative
@@ -20,11 +20,11 @@ export class AppPageUITextNative
     description: 'Native texts using CSS.',
   };
 
-  @UseQuery() readonly query!: {items?: number};
+  @useSearchParams() readonly searchParams!: {items?: number};
 
   protected render() {
     return repeat(
-      Number(this.query.items || 1),
+      Number(this.searchParams.items || 1),
       i => html`
         <span>Text (#${i})</span>
         <span class="code">Code text (#${i})</span>

--- a/apps/benchmark.tinijs.dev/app/pages/subjects/ui-text.ts
+++ b/apps/benchmark.tinijs.dev/app/pages/subjects/ui-text.ts
@@ -1,8 +1,8 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 import type {PageWithMetadata} from '@tinijs/meta';
-import {UseQuery} from '@tinijs/router';
+import {useSearchParams} from '@tinijs/router';
 
 import {TiniTextComponent} from '../../ui/components/text.js';
 
@@ -10,7 +10,7 @@ import {repeat} from '../../utils/subject.js';
 
 import {TEXT_SUBJECT} from '../../subjects.js';
 
-@Page({
+@page({
   name: 'app-page-ui-text',
   components: [TiniTextComponent],
 })
@@ -20,11 +20,11 @@ export class AppPageUIText extends TiniComponent implements PageWithMetadata {
     description: 'The tini-text component.',
   };
 
-  @UseQuery() readonly query!: {items?: number};
+  @useSearchParams() readonly searchParams!: {items?: number};
 
   protected render() {
     return repeat(
-      Number(this.query.items || 1),
+      Number(this.searchParams.items || 1),
       i => html`
         <tini-text>Text (#${i})</tini-text>
         <tini-text font="code">Code text (#${i})</tini-text>

--- a/apps/tinijs.dev/app/app.ts
+++ b/apps/tinijs.dev/app/app.ts
@@ -1,9 +1,9 @@
 import {html} from 'lit';
 
 import {
-  App,
-  TiniComponent,
+  app,
   registerConfig,
+  TiniComponent,
   type AppWithConfig,
 } from '@tinijs/core';
 import {createRouter, type AppWithRouter} from '@tinijs/router';
@@ -40,7 +40,7 @@ TiniCodeComponent.config({
   theme: prismThemeDark,
 });
 
-@App({
+@app({
   providers,
   components: [
     TiniBoxComponent,

--- a/apps/tinijs.dev/app/components/component-benchmark.ts
+++ b/apps/tinijs.dev/app/components/component-benchmark.ts
@@ -1,11 +1,11 @@
 import {html, css, nothing} from 'lit';
+import {property} from 'lit/decorators/property.js';
+import {state} from 'lit/decorators/state.js';
 
 import {
-  Component,
-  TiniComponent,
-  Prop,
-  Reactive,
+  component,
   sectionRender,
+  TiniComponent,
   type SectionRenderData,
   type OnCreate,
 } from '@tinijs/core';
@@ -22,17 +22,17 @@ type BenckmarkReport = Record<
   }
 >;
 
-@Component()
+@component()
 export class AppComponentBenchmarkComponent
   extends TiniComponent
   implements OnCreate
 {
   static readonly defaultTagName = 'app-component-benchmark';
 
-  @Prop() reportId!: string;
-  @Prop({type: Boolean, reflect: true}) noNote = false;
+  @property() reportId!: string;
+  @property({type: Boolean, reflect: true}) noNote = false;
 
-  @Reactive() private report: SectionRenderData<BenckmarkReport>;
+  @state() private report: SectionRenderData<BenckmarkReport>;
 
   async onCreate() {
     if (!this.reportId) throw new Error('reportId is required');

--- a/apps/tinijs.dev/app/components/component-editor/css.ts
+++ b/apps/tinijs.dev/app/components/component-editor/css.ts
@@ -1,18 +1,18 @@
 import {html, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 
 import {TiniTextareaComponent} from '../../ui/components/textarea.js';
 
 import {
-  Component,
+  component,
+  event,
   TiniComponent,
-  Input,
-  Output,
   EventEmitter,
   type OnCreate,
 } from '@tinijs/core';
 
-@Component({
+@component({
   components: [TiniTextareaComponent],
 })
 export class AppComponentEditorCSSComponent
@@ -21,13 +21,13 @@ export class AppComponentEditorCSSComponent
 {
   static readonly defaultTagName = 'app-component-editor-css';
 
-  @Input() label!: string;
-  @Input() placeholder?: string;
+  @property() label!: string;
+  @property() placeholder?: string;
 
-  @Input() target!: string;
-  @Input() value?: string;
+  @property() target!: string;
+  @property() value?: string;
 
-  @Output() change!: EventEmitter<string>;
+  @event() change!: EventEmitter<string>;
 
   onCreate() {
     if (!this.label) throw new Error('label is required');

--- a/apps/tinijs.dev/app/components/component-editor/html.ts
+++ b/apps/tinijs.dev/app/components/component-editor/html.ts
@@ -1,18 +1,18 @@
 import {html, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 
 import {TiniTextareaComponent} from '../../ui/components/textarea.js';
 
 import {
-  Component,
+  component,
+  event,
   TiniComponent,
-  Input,
-  Output,
   EventEmitter,
   type OnCreate,
 } from '@tinijs/core';
 
-@Component({
+@component({
   components: [TiniTextareaComponent],
 })
 export class AppComponentEditorHTMLComponent
@@ -21,13 +21,13 @@ export class AppComponentEditorHTMLComponent
 {
   static readonly defaultTagName = 'app-component-editor-html';
 
-  @Input() label!: string;
-  @Input() placeholder?: string;
+  @property() label!: string;
+  @property() placeholder?: string;
 
-  @Input() target!: string;
-  @Input() value?: string;
+  @property() target!: string;
+  @property() value?: string;
 
-  @Output() change!: EventEmitter<string>;
+  @event() change!: EventEmitter<string>;
 
   onCreate() {
     if (!this.label) throw new Error('label is required');

--- a/apps/tinijs.dev/app/components/component-editor/index.ts
+++ b/apps/tinijs.dev/app/components/component-editor/index.ts
@@ -1,4 +1,6 @@
 import {html, css, nothing, type TemplateResult} from 'lit';
+import {property} from 'lit/decorators/property.js';
+import {state} from 'lit/decorators/state.js';
 import {ref, createRef} from 'lit/directives/ref.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {html as staticHTML, unsafeStatic} from 'lit/static-html.js';
@@ -10,18 +12,16 @@ import type {InteractStatic} from '@interactjs/core/InteractStatic.js';
 import screenfull from 'screenfull';
 
 import {
-  Component,
-  TiniComponent,
-  Input,
-  Reactive,
+  component,
   createComponentLoader,
+  TiniComponent,
   ContrastColors,
   Sizes,
   type OnCreate,
   type OnChanges,
   type OnFirstRender,
 } from '@tinijs/core';
-import {Subscribe} from '@tinijs/store';
+import {globalState} from '@tinijs/store';
 
 import {TiniLinkComponent} from '../../ui/components/link.js';
 import {TiniIconComponent} from '../../ui/components/icon.js';
@@ -117,7 +117,7 @@ const componentLoader = createComponentLoader(
   }
 );
 
-@Component({
+@component({
   components: [
     TiniLinkComponent,
     TiniIconComponent,
@@ -146,16 +146,16 @@ export class AppComponentEditorComponent
 {
   static readonly defaultTagName = 'app-component-editor';
 
-  @Subscribe(MAIN_STORE) uiConsumerTarget = MAIN_STORE.uiConsumerTarget;
+  @globalState(MAIN_STORE) uiConsumerTarget = MAIN_STORE.uiConsumerTarget;
 
-  @Input() name!: string;
-  @Input({type: Object}) examples?: Record<string, QuickExample>;
-  @Input({type: Object}) sections!: FunctionSection[];
+  @property() name!: string;
+  @property({type: Object}) examples?: Record<string, QuickExample>;
+  @property({type: Object}) sections!: FunctionSection[];
 
-  @Reactive() commonViewport?: string;
-  @Reactive() isFullscreen = false;
-  @Reactive() selectedExampleValue = '_default';
-  @Reactive() data?: ComponentData;
+  @state() commonViewport?: string;
+  @state() isFullscreen = false;
+  @state() selectedExampleValue = '_default';
+  @state() data?: ComponentData;
 
   private readonly _mainRef = createRef<HTMLDivElement>();
   private readonly _previewRef = createRef<HTMLDivElement>();

--- a/apps/tinijs.dev/app/components/component-editor/input.ts
+++ b/apps/tinijs.dev/app/components/component-editor/input.ts
@@ -1,18 +1,18 @@
 import {html, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 
 import {
-  Component,
+  component,
+  event,
   TiniComponent,
-  Input,
-  Output,
   EventEmitter,
   type OnCreate,
 } from '@tinijs/core';
 
 import {TiniInputComponent} from '../../ui/components/input.js';
 
-@Component({
+@component({
   components: [TiniInputComponent],
 })
 export class AppComponentEditorInputComponent
@@ -21,13 +21,13 @@ export class AppComponentEditorInputComponent
 {
   static readonly defaultTagName = 'app-component-editor-input';
 
-  @Input() label!: string;
-  @Input() placeholder?: string;
+  @property() label!: string;
+  @property() placeholder?: string;
 
-  @Input() target!: string;
-  @Input() value?: string;
+  @property() target!: string;
+  @property() value?: string;
 
-  @Output() change!: EventEmitter<string>;
+  @event() change!: EventEmitter<string>;
 
   onCreate() {
     if (!this.label) throw new Error('label is required');

--- a/apps/tinijs.dev/app/components/component-editor/js.ts
+++ b/apps/tinijs.dev/app/components/component-editor/js.ts
@@ -1,12 +1,12 @@
 import {html, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 import JSON5 from 'json5';
 
 import {
-  Component,
+  component,
+  event,
   TiniComponent,
-  Input,
-  Output,
   EventEmitter,
   type OnCreate,
   type OnChanges,
@@ -14,7 +14,7 @@ import {
 
 import {TiniTextareaComponent} from '../../ui/components/textarea.js';
 
-@Component({
+@component({
   components: [TiniTextareaComponent],
 })
 export class AppComponentEditorJSComponent
@@ -23,13 +23,13 @@ export class AppComponentEditorJSComponent
 {
   static readonly defaultTagName = 'app-component-editor-js';
 
-  @Input() label!: string;
-  @Input() placeholder?: string;
+  @property() label!: string;
+  @property() placeholder?: string;
 
-  @Input() target!: string;
-  @Input({type: Object}) value?: Record<string, any>;
+  @property() target!: string;
+  @property({type: Object}) value?: Record<string, any>;
 
-  @Output() change!: EventEmitter<Record<string, any>>;
+  @event() change!: EventEmitter<Record<string, any>>;
 
   onCreate() {
     if (!this.label) throw new Error('label is required');

--- a/apps/tinijs.dev/app/components/component-editor/plain.ts
+++ b/apps/tinijs.dev/app/components/component-editor/plain.ts
@@ -1,14 +1,15 @@
 import {html, css, nothing} from 'lit';
+import {property} from 'lit/decorators/property.js';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
 
-import {Component, TiniComponent, Input} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
-@Component()
+@component()
 export class AppComponentEditorPlainComponent extends TiniComponent {
   static readonly defaultTagName = 'app-component-editor-plain';
 
-  @Input() label?: string;
-  @Input() content!: string;
+  @property() label?: string;
+  @property() content!: string;
 
   protected render() {
     return html`

--- a/apps/tinijs.dev/app/components/component-editor/radios.ts
+++ b/apps/tinijs.dev/app/components/component-editor/radios.ts
@@ -1,10 +1,10 @@
 import {html, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
 
 import {
-  Component,
+  component,
+  event,
   TiniComponent,
-  Input,
-  Output,
   type EventEmitter,
   type OnCreate,
 } from '@tinijs/core';
@@ -14,7 +14,7 @@ import {
   type RadiosItem,
 } from '../../ui/components/radios.js';
 
-@Component({
+@component({
   components: [TiniRadiosComponent],
 })
 export class AppComponentEditorRadiosComponent
@@ -23,13 +23,13 @@ export class AppComponentEditorRadiosComponent
 {
   static readonly defaultTagName = 'app-component-editor-radios';
 
-  @Input() label!: string;
-  @Input({type: Object}) items!: RadiosItem[];
+  @property() label!: string;
+  @property({type: Object}) items!: RadiosItem[];
 
-  @Input() target!: string;
-  @Input() value?: string;
+  @property() target!: string;
+  @property() value?: string;
 
-  @Output() change!: EventEmitter<string>;
+  @event() change!: EventEmitter<string>;
 
   onCreate() {
     if (!this.label) throw new Error('label is required');

--- a/apps/tinijs.dev/app/components/component-editor/select.ts
+++ b/apps/tinijs.dev/app/components/component-editor/select.ts
@@ -1,4 +1,5 @@
 import {html, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
 
 import {
   TiniSelectComponent,
@@ -7,10 +8,9 @@ import {
 } from '../../ui/components/select.js';
 
 import {
-  Component,
+  component,
+  event,
   TiniComponent,
-  Input,
-  Output,
   Colors,
   SubtleColors,
   ContrastColors,
@@ -28,7 +28,7 @@ import {
 
 import {parseName} from '../../utils/name.js';
 
-@Component({
+@component({
   components: [TiniSelectComponent],
 })
 export class AppComponentEditorSelectComponent
@@ -37,14 +37,14 @@ export class AppComponentEditorSelectComponent
 {
   static readonly defaultTagName = 'app-component-editor-select';
 
-  @Input() label!: string;
-  @Input() preset?: string;
-  @Input({type: Object}) items?: Array<SelectOption | SelectOptgroup>;
+  @property() label!: string;
+  @property() preset?: string;
+  @property({type: Object}) items?: Array<SelectOption | SelectOptgroup>;
 
-  @Input() target!: string;
-  @Input() value?: string;
+  @property() target!: string;
+  @property() value?: string;
 
-  @Output() change!: EventEmitter<string>;
+  @event() change!: EventEmitter<string>;
 
   private colors: SelectOptgroup[] = [
     {

--- a/apps/tinijs.dev/app/components/component-editor/switch.ts
+++ b/apps/tinijs.dev/app/components/component-editor/switch.ts
@@ -1,10 +1,10 @@
 import {html, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
 
 import {
-  Component,
+  component,
+  event,
   TiniComponent,
-  Input,
-  Output,
   type EventEmitter,
   type OnCreate,
 } from '@tinijs/core';
@@ -14,7 +14,7 @@ import {
   type SwitchEventDetail,
 } from '../../ui/components/switch.js';
 
-@Component({
+@component({
   components: [TiniSwitchComponent],
 })
 export class AppComponentEditorSwitchComponent
@@ -23,12 +23,12 @@ export class AppComponentEditorSwitchComponent
 {
   static readonly defaultTagName = 'app-component-editor-switch';
 
-  @Input() label!: string;
+  @property() label!: string;
 
-  @Input() target!: string;
-  @Input() activated?: boolean;
+  @property() target!: string;
+  @property() activated?: boolean;
 
-  @Output() change!: EventEmitter<boolean>;
+  @event() change!: EventEmitter<boolean>;
 
   onCreate() {
     if (!this.label) throw new Error('label is required');

--- a/apps/tinijs.dev/app/components/component-editor/textarea.ts
+++ b/apps/tinijs.dev/app/components/component-editor/textarea.ts
@@ -1,18 +1,18 @@
 import {html, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 
 import {TiniTextareaComponent} from '../../ui/components/textarea.js';
 
 import {
-  Component,
+  component,
+  event,
   TiniComponent,
-  Input,
-  Output,
   EventEmitter,
   type OnCreate,
 } from '@tinijs/core';
 
-@Component({
+@component({
   components: [TiniTextareaComponent],
 })
 export class AppComponentEditorTextareaComponent
@@ -21,13 +21,13 @@ export class AppComponentEditorTextareaComponent
 {
   static readonly defaultTagName = 'app-component-editor-textarea';
 
-  @Input() label!: string;
-  @Input() placeholder?: string;
+  @property() label!: string;
+  @property() placeholder?: string;
 
-  @Input() target!: string;
-  @Input() value?: string;
+  @property() target!: string;
+  @property() value?: string;
 
-  @Output() change!: EventEmitter<string>;
+  @event() change!: EventEmitter<string>;
 
   onCreate() {
     if (!this.label) throw new Error('label is required');

--- a/apps/tinijs.dev/app/components/component-import.ts
+++ b/apps/tinijs.dev/app/components/component-import.ts
@@ -1,16 +1,16 @@
 import {html, css, nothing} from 'lit';
+import {property} from 'lit/decorators/property.js';
 import {pascalCase} from 'change-case';
 
 import {
-  Component,
+  component,
+  useUI,
   TiniComponent,
-  Prop,
-  UseUI,
   type UI,
   type OnCreate,
   type OnChanges,
 } from '@tinijs/core';
-import {Subscribe} from '@tinijs/store';
+import {globalState} from '@tinijs/store';
 
 import {MAIN_STORE} from '../stores/main.js';
 
@@ -20,7 +20,7 @@ import {UIConsumerTargets} from '../consts/common.js';
 
 import {AppConsumerTabsComponent} from './consumer-tabs.js';
 
-@Component({
+@component({
   components: [TiniCodeComponent, AppConsumerTabsComponent],
 })
 export class AppComponentImportComponent
@@ -29,10 +29,10 @@ export class AppComponentImportComponent
 {
   static readonly defaultTagName = 'app-component-import';
 
-  @UseUI() readonly ui!: UI;
-  @Subscribe(MAIN_STORE) uiConsumerTarget = MAIN_STORE.uiConsumerTarget;
+  @useUI() readonly ui!: UI;
+  @globalState(MAIN_STORE) uiConsumerTarget = MAIN_STORE.uiConsumerTarget;
 
-  @Prop() componentName!: string;
+  @property() componentName!: string;
 
   onCreate() {
     if (!this.componentName) throw new Error('componentName is required');
@@ -53,10 +53,10 @@ export class AppComponentImportComponent
         return `import { ${constructorName} } from '${importPath}';
 
 // globally in app.ts
-@App({ components: [ ${constructorName} ] })
+@app({ components: [ ${constructorName} ] })
 
 // or, locally in layouts, pages and components
-@Layout|Page|Component({ components: [ ${constructorName} ] })`;
+@layout|page|component({ components: [ ${constructorName} ] })`;
       }
       case UIConsumerTargets.React: {
         const reactTag = `Tini${className}`;

--- a/apps/tinijs.dev/app/components/component-usage.ts
+++ b/apps/tinijs.dev/app/components/component-usage.ts
@@ -1,11 +1,11 @@
 import {html, css, nothing, type TemplateResult} from 'lit';
+import {property} from 'lit/decorators/property.js';
+import {state} from 'lit/decorators/state.js';
 import {classMap} from 'lit/directives/class-map.js';
 
 import {
-  Component,
+  component,
   TiniComponent,
-  Prop,
-  Reactive,
   type OnCreate,
   type OnChanges,
 } from '@tinijs/core';
@@ -20,7 +20,7 @@ import {buildUsageCode, type BuildCodeDef} from '../utils/code.js';
 
 import {AppConsumerTabsComponent} from './consumer-tabs.js';
 
-@Component({
+@component({
   components: [TiniCodeComponent, AppConsumerTabsComponent],
 })
 export class AppComponentUsageComponent
@@ -29,9 +29,9 @@ export class AppComponentUsageComponent
 {
   static readonly defaultTagName = 'app-component-usage';
 
-  @Prop() codes!: Array<BuildCodeDef | Record<string, TemplateResult>>;
+  @property() codes!: Array<BuildCodeDef | Record<string, TemplateResult>>;
 
-  @Reactive() uiConsumerTarget?: UIConsumerTargets;
+  @state() uiConsumerTarget?: UIConsumerTargets;
 
   onCreate() {
     if (!this.codes?.length) throw new Error('codes is required');

--- a/apps/tinijs.dev/app/components/consumer-tabs.ts
+++ b/apps/tinijs.dev/app/components/consumer-tabs.ts
@@ -1,11 +1,11 @@
 import {html, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
 import {classMap} from 'lit/directives/class-map.js';
 
 import {
-  Component,
+  component,
+  event,
   TiniComponent,
-  Prop,
-  Event,
   Sizes,
   type EventEmitter,
 } from '@tinijs/core';
@@ -19,7 +19,7 @@ import {IconHTMLComponent} from '../icons/html.js';
 
 import {UIConsumerTargets} from '../consts/common.js';
 
-@Component({
+@component({
   components: [
     IconTiniComponent,
     IconVueComponent,
@@ -32,9 +32,9 @@ import {UIConsumerTargets} from '../consts/common.js';
 export class AppConsumerTabsComponent extends TiniComponent {
   static readonly defaultTagName = 'app-consumer-tabs';
 
-  @Prop() target?: string;
+  @property() target?: string;
 
-  @Event() change!: EventEmitter<UIConsumerTargets>;
+  @event() change!: EventEmitter<UIConsumerTargets>;
 
   private changeTarget(target: UIConsumerTargets) {
     this.target = target;

--- a/apps/tinijs.dev/app/components/doc-page/content.ts
+++ b/apps/tinijs.dev/app/components/doc-page/content.ts
@@ -1,13 +1,13 @@
 import {html, css, unsafeCSS} from 'lit';
 import {consume} from '@lit/context';
 import {unsafeHTML} from 'lit/directives/unsafe-html.js';
+import {property} from 'lit/decorators/property.js';
 import {ref, createRef} from 'lit/directives/ref.js';
 
 import {
-  Component,
+  component,
+  event,
   TiniComponent,
-  Input,
-  Output,
   EventEmitter,
   sectionRender,
   Sizes,
@@ -15,7 +15,7 @@ import {
   type SectionRenderData,
   type OnRenders,
 } from '@tinijs/core';
-import {UseRouter, type Router, type FragmentItem} from '@tinijs/router';
+import {useRouter, type Router, type FragmentItem} from '@tinijs/router';
 
 import {TiniMessageComponent} from '../../ui/components/message.js';
 import {TiniCodeComponent} from '../../ui/components/code.js';
@@ -30,7 +30,7 @@ import {IconEditComponent} from '../../icons/edit.js';
 
 import {prismThemeDark} from '../../utils/prism.js';
 
-@Component({
+@component({
   components: [
     TiniMessageComponent,
     TiniCodeComponent,
@@ -45,14 +45,14 @@ export class AppDocPageContentComponent
 {
   static readonly defaultTagName = 'app-doc-page-content';
 
-  @UseRouter() readonly router!: Router;
+  @useRouter() readonly router!: Router;
 
   @consume({context: docPageContext}) context!: DocPageContext;
 
-  @Input() postSlug?: string;
-  @Input() post: SectionRenderData<DocPostDetail>;
+  @property() postSlug?: string;
+  @property() post: SectionRenderData<DocPostDetail>;
 
-  @Output() renewFragments!: EventEmitter<FragmentItem[]>;
+  @event() renewFragments!: EventEmitter<FragmentItem[]>;
 
   private _articleRef = createRef<HTMLElement>();
 

--- a/apps/tinijs.dev/app/components/doc-page/index.ts
+++ b/apps/tinijs.dev/app/components/doc-page/index.ts
@@ -1,22 +1,22 @@
 import {html, css} from 'lit';
 import {provide} from '@lit/context';
+import {property} from 'lit/decorators/property.js';
+import {state} from 'lit/decorators/state.js';
 import {ref, createRef} from 'lit/directives/ref.js';
 
 import {
-  Component,
+  component,
   TiniComponent,
-  Input,
-  Reactive,
   createComponentLoader,
   type SectionRenderData,
   type OnCreate,
   type OnInit,
   type OnDestroy,
 } from '@tinijs/core';
-import {UseMeta, type Meta} from '@tinijs/meta';
+import {useMeta, type Meta} from '@tinijs/meta';
 import {
-  UseRouter,
-  UseParams,
+  useRouter,
+  useParams,
   ROUTE_CHANGE_EVENT,
   type Router,
   type FragmentItem,
@@ -53,7 +53,7 @@ const componentLoader = createComponentLoader(
   }
 );
 
-@Component({
+@component({
   components: [
     AppDocPageMobileToolbarComponent,
     AppDocPageMenuComponent,
@@ -67,19 +67,19 @@ export class AppDocPageComponent
   implements OnCreate, OnInit, OnDestroy
 {
   static readonly defaultTagName = 'app-doc-page';
-  @UseMeta() readonly meta!: Meta;
-  @UseRouter() readonly router!: Router;
-  @UseParams() readonly params!: {slug?: string};
+  @useMeta() readonly meta!: Meta;
+  @useRouter() readonly router!: Router;
+  @useParams() readonly params!: {slug?: string};
 
   @provide({context: docPageContext})
-  @Input()
+  @property()
   context!: DocPageContext;
 
-  @Input() categoryService!: CategoryService;
-  @Input() postService!: PostService;
+  @property() categoryService!: CategoryService;
+  @property() postService!: PostService;
 
-  @Reactive() mobileMenuOpened = false;
-  @Reactive() mobileTOCOpened = false;
+  @state() mobileMenuOpened = false;
+  @state() mobileTOCOpened = false;
 
   private _currentRoutePath?: string;
   private _mobileToolbarRef = createRef<AppDocPageMobileToolbarComponent>();
@@ -95,16 +95,16 @@ export class AppDocPageComponent
     this._currentRoutePath = this.router.getActiveRoute().routePath;
   }
 
-  @Reactive() menuItems?: Array<{
+  @state() menuItems?: Array<{
     level: number;
     type: 'category' | 'post';
     item: DocCategory | DocPost;
   }>;
-  @Reactive() tocItems: FragmentItem[] = [];
-  @Reactive() allPosts?: DocPost[];
-  @Reactive() post: SectionRenderData<DocPostDetail>;
-  @Reactive() postPrev?: DocPost | null;
-  @Reactive() postNext?: DocPost | null;
+  @state() tocItems: FragmentItem[] = [];
+  @state() allPosts?: DocPost[];
+  @state() post: SectionRenderData<DocPostDetail>;
+  @state() postPrev?: DocPost | null;
+  @state() postNext?: DocPost | null;
 
   async onInit() {
     await this._loadData(this.params.slug);

--- a/apps/tinijs.dev/app/components/doc-page/menu.ts
+++ b/apps/tinijs.dev/app/components/doc-page/menu.ts
@@ -1,12 +1,12 @@
 import {html, css} from 'lit';
 import {consume} from '@lit/context';
+import {property} from 'lit/decorators/property.js';
 import {classMap} from 'lit/directives/class-map.js';
 
 import {
-  Component,
+  component,
+  event,
   TiniComponent,
-  Input,
-  Output,
   EventEmitter,
   sectionRender,
   ContrastColors,
@@ -28,7 +28,7 @@ export interface MenuItem {
   item: DocCategory | DocPost;
 }
 
-@Component({
+@component({
   components: [IconHomeComponent, TiniLinkComponent, TiniSkeletonComponent],
 })
 export class AppDocPageMenuComponent extends TiniComponent {
@@ -36,10 +36,10 @@ export class AppDocPageMenuComponent extends TiniComponent {
 
   @consume({context: docPageContext}) context!: DocPageContext;
 
-  @Input() mobileOpened?: boolean;
-  @Input() menuItems: SectionRenderData<MenuItem[]>;
+  @property() mobileOpened?: boolean;
+  @property() menuItems: SectionRenderData<MenuItem[]>;
 
-  @Output() selectItem!: EventEmitter<void>;
+  @event() selectItem!: EventEmitter<void>;
 
   protected render() {
     return html`

--- a/apps/tinijs.dev/app/components/doc-page/mobile-toolbar.ts
+++ b/apps/tinijs.dev/app/components/doc-page/mobile-toolbar.ts
@@ -1,11 +1,11 @@
 import {html, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
 import {ref, createRef} from 'lit/directives/ref.js';
 
 import {
-  Component,
+  component,
+  event,
   TiniComponent,
-  Input,
-  Output,
   EventEmitter,
   Sizes,
   ContrastColors,
@@ -17,17 +17,17 @@ import {IconUpComponent} from '../../icons/up.js';
 import {IconDownComponent} from '../../icons/down.js';
 import {IconMenuComponent} from '../../icons/menu.js';
 
-@Component({
+@component({
   components: [TiniIconComponent, IconMenuComponent],
 })
 export class AppDocPageMobileToolbarComponent extends TiniComponent {
   static readonly defaultTagName = 'app-doc-page-mobile-toolbar';
 
-  @Input() menuOpened?: boolean;
-  @Input() tocOpened?: boolean;
+  @property() menuOpened?: boolean;
+  @property() tocOpened?: boolean;
 
-  @Output() toggleMenu!: EventEmitter<void>;
-  @Output() toggleTOC!: EventEmitter<void>;
+  @event() toggleMenu!: EventEmitter<void>;
+  @event() toggleTOC!: EventEmitter<void>;
 
   menuTogglerRef = createRef<HTMLButtonElement>();
   tocTogglerRef = createRef<HTMLButtonElement>();

--- a/apps/tinijs.dev/app/components/doc-page/surround.ts
+++ b/apps/tinijs.dev/app/components/doc-page/surround.ts
@@ -1,29 +1,23 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
 import {consume} from '@lit/context';
 
-import {
-  Component,
-  TiniComponent,
-  Input,
-  Output,
-  EventEmitter,
-  type OnCreate,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import type {DocPost} from '../../services/content.js';
 
 import {docPageContext, type DocPageContext} from '../../contexts/doc-page.js';
 
-@Component()
+@component()
 export class AppDocPageSurroundComponent extends TiniComponent {
   static readonly defaultTagName = 'app-doc-page-surround';
 
   @consume({context: docPageContext}) context!: DocPageContext;
 
-  @Input() isFirstPost?: boolean;
+  @property() isFirstPost?: boolean;
 
-  @Input() postPrev?: DocPost;
-  @Input() postNext?: DocPost;
+  @property() postPrev?: DocPost;
+  @property() postNext?: DocPost;
 
   protected render() {
     return html`

--- a/apps/tinijs.dev/app/components/doc-page/toc.ts
+++ b/apps/tinijs.dev/app/components/doc-page/toc.ts
@@ -1,26 +1,25 @@
 import {html, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
 import {classMap} from 'lit/directives/class-map.js';
 
 import {
-  Component,
-  TiniComponent,
-  Input,
-  Output,
-  EventEmitter,
+  component,
+  event,
   sectionRender,
+  TiniComponent,
+  EventEmitter,
   type SectionRenderData,
-  type OnCreate,
 } from '@tinijs/core';
 import {type FragmentItem} from '@tinijs/router';
 
-@Component()
+@component()
 export class AppDocPageTOCComponent extends TiniComponent {
   static readonly defaultTagName = 'app-doc-page-toc';
 
-  @Input() mobileOpened?: boolean;
-  @Input() tocItems: SectionRenderData<FragmentItem[]>;
+  @property() mobileOpened?: boolean;
+  @property() tocItems: SectionRenderData<FragmentItem[]>;
 
-  @Output() selectItem!: EventEmitter<void>;
+  @event() selectItem!: EventEmitter<void>;
 
   private _scrollTop() {
     this.selectItem.emit();

--- a/apps/tinijs.dev/app/components/footer.ts
+++ b/apps/tinijs.dev/app/components/footer.ts
@@ -1,8 +1,8 @@
 import {html} from 'lit';
 
-import {Component, TiniComponent} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
-@Component()
+@component()
 export class FooterComponent extends TiniComponent {
   static readonly defaultTagName = 'app-footer';
 

--- a/apps/tinijs.dev/app/components/header.ts
+++ b/apps/tinijs.dev/app/components/header.ts
@@ -1,10 +1,10 @@
 import {html, css} from 'lit';
+import {state} from 'lit/decorators/state.js';
 import {classMap} from 'lit/directives/class-map.js';
 
 import {
-  Component,
+  component,
   TiniComponent,
-  Reactive,
   ContrastColors,
   type OnCreate,
   type OnDestroy,
@@ -25,7 +25,7 @@ import {IconDiscordComponent} from '../icons/discord.js';
 import {AppSkinEditorTogglerComponent} from './skin-editor/toggler.js';
 import {AppSkinEditorComponent} from './skin-editor/index.js';
 
-@Component({
+@component({
   components: [
     TiniLinkComponent,
     TiniIconComponent,
@@ -42,7 +42,7 @@ export class HeaderComponent
 {
   static readonly defaultTagName = 'app-header';
 
-  @Reactive() mobileMenuOpened = false;
+  @state() mobileMenuOpened = false;
 
   private _onRouteChange = () => (this.mobileMenuOpened = false);
   onCreate() {

--- a/apps/tinijs.dev/app/components/skin-editor/index.ts
+++ b/apps/tinijs.dev/app/components/skin-editor/index.ts
@@ -3,15 +3,15 @@ import {queryAll} from 'lit/decorators.js';
 import {repeat} from 'lit/directives/repeat.js';
 import {ref, createRef} from 'lit/directives/ref.js';
 import {
-  Component,
-  TiniComponent,
-  UseUI,
+  component,
+  useUI,
   listify,
   stylesToText,
+  TiniComponent,
   type UI,
   type Styles,
 } from '@tinijs/core';
-import {Subscribe} from '@tinijs/store';
+import {globalState} from '@tinijs/store';
 
 import {TiniCodeComponent} from '../../ui/components/code.js';
 import {TiniButtonComponent} from '../../ui/components/button.js';
@@ -32,7 +32,7 @@ import {buildColorVariants} from '../../utils/color.js';
 
 import {IconCodeComponent} from '../../icons/code.js';
 
-@Component({
+@component({
   components: [
     TiniCodeComponent,
     TiniButtonComponent,
@@ -44,9 +44,9 @@ import {IconCodeComponent} from '../../icons/code.js';
 export class AppSkinEditorComponent extends TiniComponent {
   static readonly defaultTagName = 'app-skin-editor';
 
-  @UseUI() readonly ui!: UI;
+  @useUI() readonly ui!: UI;
   @queryAll('.field') private allInputs!: NodeListOf<HTMLElement>;
-  @Subscribe(MAIN_STORE) skinEditorShown = MAIN_STORE.skinEditorShown;
+  @globalState(MAIN_STORE) skinEditorShown = MAIN_STORE.skinEditorShown;
 
   private modalRef = createRef<TiniModalComponent>();
   private modalContentRef = createRef<HTMLDivElement>();

--- a/apps/tinijs.dev/app/components/skin-editor/toggler.ts
+++ b/apps/tinijs.dev/app/components/skin-editor/toggler.ts
@@ -1,18 +1,19 @@
 import {html, css, nothing} from 'lit';
+import {property} from 'lit/decorators/property.js';
 
-import {Component, TiniComponent, Input, Sizes} from '@tinijs/core';
+import {component, TiniComponent, Sizes} from '@tinijs/core';
 
 import {MAIN_STORE} from '../../stores/main.js';
 
 import {IconThemeComponent} from '../../icons/theme.js';
 
-@Component({
+@component({
   components: [IconThemeComponent],
 })
 export class AppSkinEditorTogglerComponent extends TiniComponent {
   static readonly defaultTagName = 'app-skin-editor-toggler';
 
-  @Input({type: Boolean, reflect: true}) showText = false;
+  @property({type: Boolean, reflect: true}) showText = false;
 
   private _toggleSkinEditor() {
     MAIN_STORE.skinEditorShown = !MAIN_STORE.skinEditorShown;

--- a/apps/tinijs.dev/app/components/theme-selector.ts
+++ b/apps/tinijs.dev/app/components/theme-selector.ts
@@ -1,10 +1,10 @@
 import {html, css} from 'lit';
 
 import {
-  Component,
+  component,
+  event,
+  useUI,
   TiniComponent,
-  Event,
-  UseUI,
   type UI,
   type EventEmitter,
 } from '@tinijs/core';
@@ -14,15 +14,15 @@ import {
   type SelectOption,
 } from '../ui/components/select.js';
 
-@Component({
+@component({
   components: [TiniSelectComponent],
 })
 export class AppThemeSelectorComponent extends TiniComponent {
   static readonly defaultTagName = 'app-theme-selector';
 
-  @UseUI() readonly ui!: UI;
+  @useUI() readonly ui!: UI;
 
-  @Event() change!: EventEmitter<string>;
+  @event() change!: EventEmitter<string>;
 
   private buildThemeOptions(familyId: string, items: SelectOption[]) {
     return items.map(item => {

--- a/apps/tinijs.dev/app/layouts/default.ts
+++ b/apps/tinijs.dev/app/layouts/default.ts
@@ -1,11 +1,11 @@
 import {html, css} from 'lit';
 
-import {Layout, TiniComponent} from '@tinijs/core';
+import {layout, TiniComponent} from '@tinijs/core';
 
 import {HeaderComponent} from '../components/header.js';
 import {FooterComponent} from '../components/footer.js';
 
-@Layout({
+@layout({
   name: 'app-layout-default',
   components: [HeaderComponent, FooterComponent],
 })

--- a/apps/tinijs.dev/app/pages/404.ts
+++ b/apps/tinijs.dev/app/pages/404.ts
@@ -1,10 +1,10 @@
 import {html} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 import type {PageWithMetadata, PageMetadata} from '@tinijs/meta';
 import {TiniLinkComponent} from '../ui/components/link.js';
 
-@Page({
+@page({
   name: 'app-page-404',
   components: [TiniLinkComponent],
 })

--- a/apps/tinijs.dev/app/pages/cli.ts
+++ b/apps/tinijs.dev/app/pages/cli.ts
@@ -1,6 +1,6 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent, Texts, Spaces, Radiuses} from '@tinijs/core';
+import {page, TiniComponent, Texts, Spaces, Radiuses} from '@tinijs/core';
 
 import {GITHUB_CONTENT_PATH} from '../consts/common.js';
 
@@ -8,7 +8,7 @@ import {cliCategoryService, cliPostService} from '../services/content.js';
 
 import {AppDocPageComponent} from '../components/doc-page/index.js';
 
-@Page({
+@page({
   name: 'app-page-cli',
   components: [AppDocPageComponent],
 })

--- a/apps/tinijs.dev/app/pages/framework.ts
+++ b/apps/tinijs.dev/app/pages/framework.ts
@@ -1,7 +1,7 @@
 import {html} from 'lit';
 
 import {
-  Page,
+  page,
   TiniComponent,
   SubtleColors,
   Texts,
@@ -19,7 +19,7 @@ import {
 
 import {AppDocPageComponent} from '../components/doc-page/index.js';
 
-@Page({
+@page({
   name: 'app-page-framework',
   components: [TiniMessageComponent, AppDocPageComponent],
 })

--- a/apps/tinijs.dev/app/pages/home.ts
+++ b/apps/tinijs.dev/app/pages/home.ts
@@ -1,7 +1,7 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent, Colors, Gradients} from '@tinijs/core';
-import {UseRouter, Router} from '@tinijs/router';
+import {page, TiniComponent, Colors, Gradients} from '@tinijs/core';
+import {useRouter, Router} from '@tinijs/router';
 import {TiniTextComponent} from '../ui/components/text.js';
 import {TiniButtonComponent} from '../ui/components/button.js';
 import {TiniEmbedComponent} from '../ui/components/embed.js';
@@ -10,7 +10,7 @@ import {IconHeartComponent} from '../icons/heart.js';
 
 import {LOGO_URL} from '../consts/common.js';
 
-@Page({
+@page({
   name: 'app-page-home',
   components: [
     TiniTextComponent,
@@ -20,7 +20,7 @@ import {LOGO_URL} from '../consts/common.js';
   ],
 })
 export class AppPageHome extends TiniComponent {
-  @UseRouter() readonly router!: Router;
+  @useRouter() readonly router!: Router;
 
   protected render() {
     return html`

--- a/apps/tinijs.dev/app/pages/module.ts
+++ b/apps/tinijs.dev/app/pages/module.ts
@@ -1,6 +1,6 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent, Texts, Spaces, Radiuses} from '@tinijs/core';
+import {page, TiniComponent, Texts, Spaces, Radiuses} from '@tinijs/core';
 
 import {GITHUB_CONTENT_PATH} from '../consts/common.js';
 
@@ -8,7 +8,7 @@ import {moduleCategoryService, modulePostService} from '../services/content.js';
 
 import {AppDocPageComponent} from '../components/doc-page/index.js';
 
-@Page({
+@page({
   name: 'app-page-module',
   components: [AppDocPageComponent],
 })

--- a/apps/tinijs.dev/app/pages/toolbox.ts
+++ b/apps/tinijs.dev/app/pages/toolbox.ts
@@ -1,6 +1,6 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent, Texts, Spaces, Radiuses} from '@tinijs/core';
+import {page, TiniComponent, Texts, Spaces, Radiuses} from '@tinijs/core';
 
 import {GITHUB_CONTENT_PATH} from '../consts/common.js';
 
@@ -11,7 +11,7 @@ import {
 
 import {AppDocPageComponent} from '../components/doc-page/index.js';
 
-@Page({
+@page({
   name: 'app-page-toolbox',
   components: [AppDocPageComponent],
 })

--- a/apps/tinijs.dev/app/pages/ui-dev/badge.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/badge.ts
@@ -1,10 +1,10 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent, Colors, Gradients, Sizes} from '@tinijs/core';
+import {component, TiniComponent, Colors, Gradients, Sizes} from '@tinijs/core';
 
 import {TiniBadgeComponent} from '../../ui/components/badge.js';
 
-@Component({
+@component({
   components: [TiniBadgeComponent],
 })
 export class AppPageUIDevBadgeComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/box.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/box.ts
@@ -1,10 +1,10 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent, Shadows} from '@tinijs/core';
+import {component, TiniComponent, Shadows} from '@tinijs/core';
 
 import {TiniBoxComponent} from '../../ui/components/box.js';
 
-@Component({
+@component({
   components: [TiniBoxComponent],
 })
 export class AppPageUIDevBoxComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/breadcrumbs.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/breadcrumbs.ts
@@ -1,6 +1,6 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {
   TiniBreadcrumbsComponent,
@@ -13,7 +13,7 @@ const ITEMS: BreadcrumbsItem[] = [
   {content: 'Data', href: '#data'},
 ];
 
-@Component({
+@component({
   components: [TiniBreadcrumbsComponent],
 })
 export class AppPageUIDevBreadcrumbsComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/button.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/button.ts
@@ -1,10 +1,10 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent, Colors, Gradients, Sizes} from '@tinijs/core';
+import {component, TiniComponent, Colors, Gradients, Sizes} from '@tinijs/core';
 
 import {TiniButtonComponent} from '../../ui/components/button.js';
 
-@Component({
+@component({
   components: [TiniButtonComponent],
 })
 export class AppPageUIDevButtonComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/card.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/card.ts
@@ -1,18 +1,10 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
-import {
-  Component,
-  TiniComponent,
-  Colors,
-  SubtleColors,
-  Gradients,
-  SubtleGradients,
-  Sizes,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniCardComponent} from '../../ui/components/card.js';
 
-@Component({
+@component({
   components: [TiniCardComponent],
 })
 export class AppPageUIDevCardComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/checkboxes.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/checkboxes.ts
@@ -1,18 +1,10 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
-import {
-  Component,
-  TiniComponent,
-  Colors,
-  SubtleColors,
-  Gradients,
-  SubtleGradients,
-  Sizes,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniCheckboxesComponent} from '../../ui/components/checkboxes.js';
 
-@Component({
+@component({
   components: [TiniCheckboxesComponent],
 })
 export class AppPageUIDevCheckboxesComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/code.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/code.ts
@@ -1,10 +1,10 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniCodeComponent} from '../../ui/components/code.js';
 
-@Component({
+@component({
   components: [TiniCodeComponent],
 })
 export class AppPageUIDevCodeComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/container.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/container.ts
@@ -1,10 +1,10 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniContainerComponent} from '../../ui/components/container.js';
 
-@Component({
+@component({
   components: [TiniContainerComponent],
 })
 export class AppPageUIDevContainerComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/dialog.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/dialog.ts
@@ -1,18 +1,10 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
-import {
-  Component,
-  TiniComponent,
-  Colors,
-  SubtleColors,
-  Gradients,
-  SubtleGradients,
-  Sizes,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniDialogComponent} from '../../ui/components/dialog.js';
 
-@Component({
+@component({
   components: [TiniDialogComponent],
 })
 export class AppPageUIDevDialogComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/embed.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/embed.ts
@@ -1,10 +1,10 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniEmbedComponent} from '../../ui/components/embed.js';
 
-@Component({
+@component({
   components: [TiniEmbedComponent],
 })
 export class AppPageUIDevEmbedComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/flex.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/flex.ts
@@ -1,11 +1,11 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniBoxComponent} from '../../ui/components/box.js';
 import {TiniFlexComponent} from '../../ui/components/flex.js';
 
-@Component({
+@component({
   components: [TiniBoxComponent, TiniFlexComponent],
 })
 export class AppPageUIDevFlexComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/grid.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/grid.ts
@@ -1,11 +1,11 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniBoxComponent} from '../../ui/components/box.js';
 import {TiniGridComponent} from '../../ui/components/grid.js';
 
-@Component({
+@component({
   components: [TiniBoxComponent, TiniGridComponent],
 })
 export class AppPageUIDevGridComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/heading.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/heading.ts
@@ -1,10 +1,10 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent, Colors, Gradients} from '@tinijs/core';
+import {component, TiniComponent, Colors, Gradients} from '@tinijs/core';
 
 import {TiniHeadingComponent} from '../../ui/components/heading.js';
 
-@Component({
+@component({
   components: [TiniHeadingComponent],
 })
 export class AppPageUIDevHeadingComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/icon.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/icon.ts
@@ -1,6 +1,6 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent, Colors, Gradients, Sizes} from '@tinijs/core';
+import {component, TiniComponent, Colors, Gradients, Sizes} from '@tinijs/core';
 
 import {TiniIconComponent} from '../../ui/components/icon.js';
 
@@ -12,7 +12,7 @@ const URI_COLOR =
 const URI_ANIMATED =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' viewBox='0 0 512 512'%3E%3Cdefs%3E%3ClinearGradient id='meteoconsUvIndex1Fill0' x1='150' x2='234' y1='119.2' y2='264.8' gradientUnits='userSpaceOnUse'%3E%3Cstop offset='0' stop-color='%23fbbf24'/%3E%3Cstop offset='.5' stop-color='%23fbbf24'/%3E%3Cstop offset='1' stop-color='%23f59e0b'/%3E%3C/linearGradient%3E%3CclipPath id='meteoconsUvIndex1Fill1'%3E%3Cpath fill='none' d='M64 64h384v192H328a72 72 0 0 0-72 72v120H64Z'/%3E%3C/clipPath%3E%3Csymbol id='meteoconsUvIndex1Fill2' viewBox='0 0 384 384'%3E%3Ccircle cx='192' cy='192' r='84' fill='url(%23meteoconsUvIndex1Fill0)' stroke='%23f8af18' stroke-miterlimit='10' stroke-width='6'/%3E%3Cpath fill='none' stroke='%23fbbf24' stroke-linecap='round' stroke-miterlimit='10' stroke-width='24' d='M192 61.7V12m0 360v-49.7m92.2-222.5l35-35M64.8 319.2l35.1-35.1m0-184.4l-35-35m254.5 254.5l-35.1-35.1M61.7 192H12m360 0h-49.7'%3E%3CanimateTransform additive='sum' attributeName='transform' dur='1s' repeatCount='indefinite' type='rotate' values='0 192 192; 45 192 192'/%3E%3C/path%3E%3C/symbol%3E%3C/defs%3E%3Cg clip-path='url(%23meteoconsUvIndex1Fill1)'%3E%3Cuse width='384' height='384' href='%23meteoconsUvIndex1Fill2' transform='translate(64 64)'/%3E%3Cpath fill='none' stroke='%23f8af18' stroke-miterlimit='10' stroke-width='6' d='M254 338v-10a74 74 0 0 1 74-74h10'/%3E%3C/g%3E%3Crect width='144' height='144' x='280' y='280' fill='%2391c700' rx='48'/%3E%3Cpath fill='%23fff' d='M366.4 388h-19v-45h-17.8v-12.6h3q7.8 0 12.4-3.4q4.2-3.1 5.5-10.2l.2-.8h15.6Z'/%3E%3C/svg%3E";
 
-@Component({
+@component({
   components: [TiniIconComponent],
 })
 export class AppPageUIDevIconComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/image.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/image.ts
@@ -1,13 +1,13 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent, Shadows} from '@tinijs/core';
+import {component, TiniComponent, Shadows} from '@tinijs/core';
 
 import {TiniImageComponent} from '../../ui/components/image.js';
 
 const SRC =
   'https://images.unsplash.com/photo-1501854140801-50d01698950b?auto=format&fit=crop&w=1024&q=80';
 
-@Component({
+@component({
   components: [TiniImageComponent],
 })
 export class AppPageUIDevImageComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/index.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/index.ts
@@ -1,18 +1,18 @@
 import {css, nothing} from 'lit';
+import {property} from 'lit/decorators/property.js';
+import {state} from 'lit/decorators/state.js';
 import {html, unsafeStatic} from 'lit/static-html.js';
 
 import {
-  Component,
-  Page,
+  component,
+  page,
   TiniComponent,
-  Input,
-  Reactive,
   createComponentLoader,
   type OnCreate,
   type OnChanges,
 } from '@tinijs/core';
-import {UseMeta, type Meta} from '@tinijs/meta';
-import {UseParams} from '@tinijs/router';
+import {useMeta, type Meta} from '@tinijs/meta';
+import {useParams} from '@tinijs/router';
 
 const componentLoader = createComponentLoader({
   box: () => import('./box.js'),
@@ -46,12 +46,12 @@ const componentLoader = createComponentLoader({
   textarea: () => import('./textarea.js'),
 });
 
-@Component()
+@component()
 class UIDevSectionComponent extends TiniComponent implements OnCreate {
   static readonly defaultTagName = 'ui-dev-section';
 
-  @Input() titleText!: string;
-  @Input() description?: string;
+  @property() titleText!: string;
+  @property() description?: string;
 
   onCreate() {
     if (!this.titleText) throw new Error('titleText is required');
@@ -111,15 +111,15 @@ class UIDevSectionComponent extends TiniComponent implements OnCreate {
   `;
 }
 
-@Page({
+@page({
   name: 'app-page-ui-dev',
   components: [UIDevSectionComponent],
 })
 export class AppPageUIDev extends TiniComponent implements OnCreate, OnChanges {
-  @UseParams() readonly params!: {slug: string};
-  @UseMeta() readonly meta!: Meta;
+  @useParams() readonly params!: {slug: string};
+  @useMeta() readonly meta!: Meta;
 
-  @Reactive() private componentName: string | null | undefined;
+  @state() private componentName: string | null | undefined;
 
   onCreate() {
     componentLoader

--- a/apps/tinijs.dev/app/pages/ui-dev/input.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/input.ts
@@ -1,18 +1,10 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
-import {
-  Component,
-  TiniComponent,
-  Colors,
-  SubtleColors,
-  Gradients,
-  SubtleGradients,
-  Sizes,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniInputComponent} from '../../ui/components/input.js';
 
-@Component({
+@component({
   components: [TiniInputComponent],
 })
 export class AppPageUIDevInputComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/label.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/label.ts
@@ -1,18 +1,10 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
-import {
-  Component,
-  TiniComponent,
-  Colors,
-  SubtleColors,
-  Gradients,
-  SubtleGradients,
-  Sizes,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniLabelComponent} from '../../ui/components/label.js';
 
-@Component({
+@component({
   components: [TiniLabelComponent],
 })
 export class AppPageUIDevLabelComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/link.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/link.ts
@@ -1,7 +1,7 @@
 import {html, css} from 'lit';
 
 import {
-  Component,
+  component,
   TiniComponent,
   Colors,
   Gradients,
@@ -11,7 +11,7 @@ import {
 
 import {TiniLinkComponent} from '../../ui/components/link.js';
 
-@Component({
+@component({
   components: [TiniLinkComponent],
 })
 export class AppPageUIDevLinkComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/message.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/message.ts
@@ -1,18 +1,10 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
-import {
-  Component,
-  TiniComponent,
-  Colors,
-  SubtleColors,
-  Gradients,
-  SubtleGradients,
-  Sizes,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniMessageComponent} from '../../ui/components/message.js';
 
-@Component({
+@component({
   components: [TiniMessageComponent],
 })
 export class AppPageUIDevMessageComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/modal.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/modal.ts
@@ -1,18 +1,10 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
-import {
-  Component,
-  TiniComponent,
-  Colors,
-  SubtleColors,
-  Gradients,
-  SubtleGradients,
-  Sizes,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniModalComponent} from '../../ui/components/modal.js';
 
-@Component({
+@component({
   components: [TiniModalComponent],
 })
 export class AppPageUIDevModalComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/pagination.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/pagination.ts
@@ -1,18 +1,10 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
-import {
-  Component,
-  TiniComponent,
-  Colors,
-  SubtleColors,
-  Gradients,
-  SubtleGradients,
-  Sizes,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniPaginationComponent} from '../../ui/components/pagination.js';
 
-@Component({
+@component({
   components: [TiniPaginationComponent],
 })
 export class AppPageUIDevPaginationComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/radios.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/radios.ts
@@ -1,18 +1,10 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
-import {
-  Component,
-  TiniComponent,
-  Colors,
-  SubtleColors,
-  Gradients,
-  SubtleGradients,
-  Sizes,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniRadiosComponent} from '../../ui/components/radios.js';
 
-@Component({
+@component({
   components: [TiniRadiosComponent],
 })
 export class AppPageUIDevRadiosComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/select.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/select.ts
@@ -1,18 +1,10 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
-import {
-  Component,
-  TiniComponent,
-  Colors,
-  SubtleColors,
-  Gradients,
-  SubtleGradients,
-  Sizes,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniSelectComponent} from '../../ui/components/select.js';
 
-@Component({
+@component({
   components: [TiniSelectComponent],
 })
 export class AppPageUIDevSelectComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/skeleton.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/skeleton.ts
@@ -1,10 +1,10 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent, Radiuses} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniSkeletonComponent} from '../../ui/components/skeleton.js';
 
-@Component({
+@component({
   components: [TiniSkeletonComponent],
 })
 export class AppPageUIDevSkeletonComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/spinner.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/spinner.ts
@@ -1,18 +1,10 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
-import {
-  Component,
-  TiniComponent,
-  Colors,
-  SubtleColors,
-  Gradients,
-  SubtleGradients,
-  Sizes,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniSpinnerComponent} from '../../ui/components/spinner.js';
 
-@Component({
+@component({
   components: [TiniSpinnerComponent],
 })
 export class AppPageUIDevSpinnerComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/switch.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/switch.ts
@@ -1,18 +1,10 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
-import {
-  Component,
-  TiniComponent,
-  Colors,
-  SubtleColors,
-  Gradients,
-  SubtleGradients,
-  Sizes,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniSwitchComponent} from '../../ui/components/switch.js';
 
-@Component({
+@component({
   components: [TiniSwitchComponent],
 })
 export class AppPageUIDevSwitchComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/table.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/table.ts
@@ -1,10 +1,10 @@
 import {html, css} from 'lit';
 
-import {Component, TiniComponent} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniTableComponent} from '../../ui/components/table.js';
 
-@Component({
+@component({
   components: [TiniTableComponent],
 })
 export class AppPageUIDevTableComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/text.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/text.ts
@@ -1,7 +1,7 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
 import {
-  Component,
+  component,
   TiniComponent,
   Colors,
   Gradients,
@@ -12,7 +12,7 @@ import {
 
 import {TiniTextComponent} from '../../ui/components/text.js';
 
-@Component({
+@component({
   components: [TiniTextComponent],
 })
 export class AppPageUIDevTextComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/textarea.ts
+++ b/apps/tinijs.dev/app/pages/ui-dev/textarea.ts
@@ -1,18 +1,10 @@
-import {html, css, nothing} from 'lit';
+import {html, css} from 'lit';
 
-import {
-  Component,
-  TiniComponent,
-  Colors,
-  SubtleColors,
-  Gradients,
-  SubtleGradients,
-  Sizes,
-} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniTextareaComponent} from '../../ui/components/textarea.js';
 
-@Component({
+@component({
   components: [TiniTextareaComponent],
 })
 export class AppPageUIDevTextareaComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui-dev/xxx.txt
+++ b/apps/tinijs.dev/app/pages/ui-dev/xxx.txt
@@ -12,7 +12,7 @@ import {
 
 import {TiniXXXComponent} from '../../ui/components/xxx.js';
 
-@Component({
+@component({
   components: [TiniXXXComponent],
 })
 export class AppPageUIDevXXXComponent extends TiniComponent {

--- a/apps/tinijs.dev/app/pages/ui.ts
+++ b/apps/tinijs.dev/app/pages/ui.ts
@@ -1,6 +1,6 @@
 import {html, css} from 'lit';
 
-import {Page, TiniComponent, Texts, Spaces, Radiuses} from '@tinijs/core';
+import {page, TiniComponent, Texts, Spaces, Radiuses} from '@tinijs/core';
 
 import {GITHUB_CONTENT_PATH} from '../consts/common.js';
 
@@ -12,7 +12,7 @@ import {AppComponentEditorComponent} from '../components/component-editor/index.
 import {AppComponentUsageComponent} from '../components/component-usage.js';
 import {AppComponentBenchmarkComponent} from '../components/component-benchmark.js';
 
-@Page({
+@page({
   name: 'app-page-ui',
   components: [
     AppDocPageComponent,

--- a/apps/tinijs.dev/content/framework-posts/204 - components/index.md
+++ b/apps/tinijs.dev/content/framework-posts/204 - components/index.md
@@ -20,9 +20,9 @@ Or, create `app/components/<name>.ts` file manually, a component looks like this
 
 ```ts
 import {html, css} from 'lit';
-import {Component, TiniComponent} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
-@Component()
+@component()
 export class AppXXXComponent extends TiniComponent {
   static readonly defaultTagName = 'app-xxx';
 
@@ -52,7 +52,7 @@ Register components **globally at the app level**, this is convenient since you 
 
 import {AppXXXComponent} from './components/xxx.js';
 
-@App({
+@app({
   components: [AppXXXComponent]
 })
 export class AppRoot extends TiniComponent {}
@@ -65,7 +65,7 @@ Components can also be registering **locally at layout, app or component level**
 
 import {AppXXXComponent} from '../components/xxx.js';
 
-@Component|Page|Layout({
+@component|page|layout({
   components: [AppXXXComponent]
 })
 export class ComponentOrPageOrLayout extends TiniComponent {}
@@ -108,7 +108,7 @@ Then, somewhere in a TiniJS app:
 ```js
 import 'my/lit/element.js';
 
-@Component()
+@component()
 export class MyTiniComponent extends TiniComponent {
   protected render() {
     return html`<my-lit-element></my-lit-element>`;
@@ -121,7 +121,7 @@ export class MyTiniComponent extends TiniComponent {
 You can also convert a Lit element to a Tini component, in 3 steps:
 - Extend `TiniComponent` instead of `LitElement`
 - Move the tag name to `defaultTagName`
-- Use `@Component()` decorator
+- Use `@component()` decorator
 
 For example, the below Lit element:
 
@@ -133,7 +133,7 @@ export class MyComponent extends LitElement {}
 Will be converted to:
 
 ```js
-@Component()
+@component()
 export class MyComponent extends TiniComponent {
   static readonly defaultTagName = 'my-component';
 }

--- a/apps/tinijs.dev/content/framework-posts/205 - properties-and-events/index.md
+++ b/apps/tinijs.dev/content/framework-posts/205 - properties-and-events/index.md
@@ -10,23 +10,17 @@ Components usually has **properties** and **events** for data exchange and inter
 
 ## Properties
 
-Use the decorator `@Prop()` or `@Input()` or `@property()` to define properties.
+Use the decorator `@property()` to define properties.
 
 ```ts
 import {property} from 'lit/decorators/property.js';
-import {Prop, Input} from '@tinijs/core';
 
-@Component()
+@component()
 export class AppXXXComponent extends TiniComponent {
 
-  // Lit syntax
   @property() prop1?: string;
-
-  // or, TiniJS syntax
-  @Prop() prop2?: {foo: number};
-
-  // or, Angular-alike syntax
-  @Input() prop3?: boolean;
+  @property() prop2?: {foo: number};
+  @property() prop3?: boolean;
 
 }
 ```
@@ -41,19 +35,16 @@ Beside define properties, you can also use **Contexts** as a form of communicati
 
 ## Events
 
-Use the decorator `@Event()` or `@Output()` to define events.
+Use the decorator `@event()` to define events.
 
 ```ts
-import {Event, Output, type EventEmitter} from '@tinijs/core';
+import {event, type EventEmitter} from '@tinijs/core';
 
-@Component()
+@component()
 export class AppXXXComponent extends TiniComponent {
 
-  // TiniJS syntax
-  @Event() event1!: EventEmitter<string>;
-
-  // or, Angular-alike syntax
-  @Output() event2!: EventEmitter<{ foo: number }>;
+  @event() event1!: EventEmitter<string>;
+  @event() event2!: EventEmitter<{ foo: number }>;
 
   emitEvent1() {
     this.event1.emit('Lorem ipsum');

--- a/apps/tinijs.dev/content/framework-posts/206 - states/index.md
+++ b/apps/tinijs.dev/content/framework-posts/206 - states/index.md
@@ -10,22 +10,18 @@ By default, class properties changes won't trigger the UI changes. In order to t
 
 ## Local states
 
-The properties defined using `@property()` or `@Input()` as we see above are already local states which means changing those properties will trigger `render()`.
+The properties defined using `@property()` as we see above are already local states which means changing those properties will trigger `render()`.
 
-To define local states but not in the form of property, use the `@state()` or `@Reactive()`.
+To define local states but not in the form of property, use the `@state()`.
 
 ```ts
 import {state} from 'lit/decorators/state.js';
-import {Reactive} from '@tinijs/core';
 
-@Component()
+@component()
 export class AppXXXComponent extends TiniComponent {
 
-  // Lit syntax
   @state() state1?: string;
-
-  // or, TiniJS syntax
-  @Reactive() state2: number = 123;
+  @state() state2: number = 123;
 
   protected render() {
     return html`
@@ -53,7 +49,7 @@ export const MAIN_STORE = createStore({
 After creating a store, you now can **access its states**, **subscribe to state changes** and **mutate states**.
 
 ```ts
-import {Subscribe} from '@tinijs/store';
+import {globalState} from '@tinijs/store';
 
 import {MAIN_STORE} from './stores/main.js';
 
@@ -77,18 +73,18 @@ MAIN_STORE.commit('foo', 'bar3');
  * Subscribe to state changes
  */
 
-@Component()
+@component()
 export class AppXXXComponent extends TiniComponent {
 
-  // Use the @Subscribe() decorator
+  // Use the @globalState() decorator
   // this.foo will be updated when MAIN_STORE.foo changes it is reactive by default
-  @Subscribe(MAIN_STORE) foo = MAIN_STORE.foo;
+  @globalState(MAIN_STORE) foo = MAIN_STORE.foo;
 
   // use a different variable name
-  @Subscribe(MAIN_STORE, 'foo') xyz = MAIN_STORE.foo;
+  @globalState(MAIN_STORE, 'foo') xyz = MAIN_STORE.foo;
 
   // to turn of reactive, set the third argument to false
-  @Subscribe(MAIN_STORE, null, false) foo = MAIN_STORE.foo;
+  @globalState(MAIN_STORE, null, false) foo = MAIN_STORE.foo;
 
   // Or, subscribe and unsubscribe manually
   onInit() {

--- a/apps/tinijs.dev/content/framework-posts/208 - async-data/index.md
+++ b/apps/tinijs.dev/content/framework-posts/208 - async-data/index.md
@@ -15,10 +15,10 @@ The `@lit/task` package provides a `Task` reactive controller to help manage thi
 ```ts
 import {Task} from '@lit/task';
 
-@Component()
+@component()
 export class AppXXXComponent extends TiniComponent {
 
-  @Reactive() productId?: string;
+  @state() productId?: string;
 
   private _productTask = new Task(this, {
     task: async ([productId], {signal}) => {
@@ -56,10 +56,10 @@ Similar to Task Render, Section Render renders a section of a page based on **th
 ```ts
 import {sectionRender, type SectionRenderData} from '@tinijs/core';
 
-@Component()
+@component()
 export class AppXXXComponent extends TiniComponent {
 
-  @Reactive() product: SectionRenderData<Product>;
+  @state() product: SectionRenderData<Product>;
 
   async onInit() {
     this.product = await fetchProduct();

--- a/apps/tinijs.dev/content/framework-posts/209 - adding-features/index.md
+++ b/apps/tinijs.dev/content/framework-posts/209 - adding-features/index.md
@@ -8,15 +8,15 @@
 
 ## The app instance
 
-As in previous topics, we can see that a TiniJS app is started with an app root defined in `./app/app.ts`, the file contains a class named `AppRoot` which extends the `TiniComponent` class and is decorated with the `@App()` decorator.
+As in previous topics, we can see that a TiniJS app is started with an app root defined in `./app/app.ts`, the file contains a class named `AppRoot` which extends the `TiniComponent` class and is decorated with the `@app()` decorator.
 
 The app root is where we initiate the app and incorporate features, a minimal app constructor looks like this:
 
 ```ts
 import {html, css} from 'lit';
-import {App, TiniComponent} from '@tinijs/core';
+import {app, TiniComponent} from '@tinijs/core';
 
-@App()
+@app()
 export class AppRoot extends TiniComponent {
 
   protected render() {
@@ -44,7 +44,7 @@ const app = document.getElementById('xxx');
 - Using util and decorator:
 
 ```ts
-import {getApp, UseApp} from '@tinijs/core';
+import {getApp, useApp} from '@tinijs/core';
 
 import type {AppRoot} from '../app.ts';
 
@@ -59,10 +59,10 @@ const meta = app.meta;
 /*
  * Or, via decorator
  */
-@Page({})
+@page({})
 export class AppPageXXX extends TiniComponent {
 
-  @UseApp() readonly app!: AppRoot;
+  @useApp() readonly app!: AppRoot;
 
   onCreate() {
     const config = this.app.config;
@@ -162,25 +162,25 @@ export const providers: DependencyProviders = {
   }
 };
 
-@App({ providers })
+@app({ providers })
 export class AppRoot extends TiniComponent {}
 ```
 
 - Step 3: **Inject dependencies**:
 
 ```ts
-import {Inject} from '@tinijs/core';
+import {inject} from '@tinijs/core';
 
 import type {FooConst} from '../consts/foo.js';
 import type {FooUtil} from '../utils/foo.js';
 import type {FooService} from '../services/foo.js';
 
-@Page({})
+@page({})
 export class AppPageXXX extends TiniComponent {
 
-  @Inject() FOO!: FooConst;
-  @Inject() foo!: FooUtil;
-  @Inject() fooService!: FooService;
+  @inject() FOO!: FooConst;
+  @inject() foo!: FooUtil;
+  @inject() fooService!: FooService;
 
   // lazy load dependencies are available started from onInit() lifecycle hook
   onInit() {
@@ -227,7 +227,7 @@ import {provide} from '@lit/context';
 
 import {pluginsContext, plugins} from './contexts/plugins.ts';
 
-@App()
+@app()
 export class AppRoot extends TiniComponent {
 
   @provide({context: pluginsContext}) $plugins = plugins;
@@ -242,7 +242,7 @@ import {consume} from '@lit/context';
 
 import {pluginsContext, type PluginsContext} from '../contexts/plugins.ts';
 
-@Page({})
+@page({})
 export class AppPageXXX extends TiniComponent {
 
   @consume({context: pluginsContext}) $plugins!: PluginsContext;
@@ -268,7 +268,7 @@ For demonstration, we will use **Vue 3** in a TiniJS app, install `npm i vue`.
 import {ref, createRef, type Ref} from 'lit/directives/ref.js';
 import {createApp} from 'vue/dist/vue.esm-bundler.js';
 
-@Page({})
+@page({})
 export class AppPageXXX extends TiniComponent {
   
   private readonly vueAppRef: Ref<HTMLDivElement> = createRef();

--- a/apps/tinijs.dev/content/framework-posts/301 - pages-and-layouts/index.md
+++ b/apps/tinijs.dev/content/framework-posts/301 - pages-and-layouts/index.md
@@ -20,9 +20,9 @@ Or, create a `./app/pages/xxx.ts` file manually, a page looks like this:
 
 ```ts
 import {html, css} from 'lit';
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 
-@Page({
+@page({
   name: 'app-page-xxx',
 })
 export class AppPageXXX extends TiniComponent {
@@ -35,7 +35,7 @@ export class AppPageXXX extends TiniComponent {
 }
 ```
 
-Beside the `@Page()` decorator, everything else would work the same as any component. But, please note the `name: 'app-page-xxx'` property, it plays a role later when we setup the [Tini Router](https://tinijs.dev/framework/router).
+Beside the `@page()` decorator, everything else would work the same as any component. But, please note the `name: 'app-page-xxx'` property, it plays a role later when we setup the [Tini Router](https://tinijs.dev/framework/router).
 
 ## Layouts
 
@@ -51,9 +51,9 @@ Or, create a `./app/layouts/xxx.ts` file manually, a layout looks like this:
 
 ```ts
 import {html, css} from 'lit';
-import {Layout, TiniComponent} from '@tinijs/core';
+import {layout, TiniComponent} from '@tinijs/core';
 
-@Layout({
+@layout({
   name: 'app-layout-xxx',
 })
 export class AppLayoutXXX extends TiniComponent {
@@ -72,7 +72,7 @@ export class AppLayoutXXX extends TiniComponent {
 }
 ```
 
-Beside the `@Layout()` decorator and the `<slot></slot>` in the template, everything else would work the same as any component. But, please note the `name: 'app-layout-xxx'` property, it plays a role later when we setup the [Tini Router](https://tinijs.dev/framework/router).
+Beside the `@layout()` decorator and the `<slot></slot>` in the template, everything else would work the same as any component. But, please note the `name: 'app-layout-xxx'` property, it plays a role later when we setup the [Tini Router](https://tinijs.dev/framework/router).
 
 ## Lit elements
 
@@ -107,7 +107,7 @@ export const routes: Route[] = [
 You can also convert a Lit page to a Tini page, in 3 steps:
 - Extend `TiniComponent` instead of `LitElement`
 - Move the tag name to `options.name`
-- Use `@Page()` decorator
+- Use `@page()` decorator
 
 For example, the below Lit page:
 
@@ -119,7 +119,7 @@ export class MyPage extends LitElement {}
 Will be converted to:
 
 ```js
-@Page({
+@page({
   name: 'my-page'
 })
 export class MyPage extends TiniComponent {}

--- a/apps/tinijs.dev/content/framework-posts/302 - router/index.md
+++ b/apps/tinijs.dev/content/framework-posts/302 - router/index.md
@@ -226,7 +226,7 @@ import {createRouter} from '@tinijs/router';
 
 import {routes} from './routes.js';
 
-@App({})
+@app({})
 export class AppRoot extends TiniComponent {
 
   readonly router = createRouter(routes, {linkTrigger: true});
@@ -261,13 +261,13 @@ You can also use the `<tini-link>` component provided by the [Tini UI](https://t
 You can also navigate between pages in the imperative manner by using the `go()` method from a router instance.
 
 ```ts
-import {getRouter, UseRouter, type Router} from '@tinijs/router';
+import {getRouter, useRouter, type Router} from '@tinijs/router';
 
-@Page({})
+@page({})
 export class AppPageXXX extends TiniComponent {
 
   // via decorator
-  @UseRouter() readonly router!: Router;
+  @useRouter() readonly router!: Router;
 
   // or, via util
   readonly router = getRouter();
@@ -282,16 +282,16 @@ export class AppPageXXX extends TiniComponent {
 Access **current route** and **params** is similar to access router instance.
 
 ```ts
-import {UseRoute, UseParams, type ActivatedRoute} from '@tinijs/router';
+import {useRoute, useParams, type ActivatedRoute} from '@tinijs/router';
 
-@Page({})
+@page({})
 export class AppPageXXX extends TiniComponent {
 
   // current route
-  @UseRoute() readonly route!: ActivatedRoute;
+  @useRoute() readonly route!: ActivatedRoute;
 
   // route params
-  @UseParams() readonly params!: {slug: string};
+  @useParams() readonly params!: {slug: string};
 
 }
 ```
@@ -310,7 +310,7 @@ You can intercept the navigation process by returning a `string` or a `function`
 - `function`: cancel and execute the function
 
 ```ts
-@Page({})
+@page({})
 export class AppPageAccount extends TiniComponent {
 
   onBeforeEnter() {
@@ -332,10 +332,10 @@ Because we use the Shadow DOM to encapsulate our app, the browser seems to be un
 ```ts
 import {ref, createRef} from 'lit/directives/ref.js';
 
-@Page({})
+@page({})
 export class AppPageXXX extends TiniComponent {
 
-  @UseRouter() readonly router!: Router;
+  @useRouter() readonly router!: Router;
 
   private _articleRef = createRef<HTMLElement>();
 

--- a/apps/tinijs.dev/content/framework-posts/303 - title-and-meta/index.md
+++ b/apps/tinijs.dev/content/framework-posts/303 - title-and-meta/index.md
@@ -19,7 +19,7 @@ To **update page title and meta** when navigating to different pages, init a met
 ```ts
 import {initMeta} from '@tinijs/meta';
 
-@App({})
+@app({})
 export class AppRoot extends TiniComponent {
 
   readonly meta = initMeta({
@@ -37,7 +37,7 @@ When `autoPageMetadata: true` for page which is static, meta can be provide via 
 ```ts
 import type {PageMetadata} from '@tinijs/meta';
 
-@Page({})
+@page({})
 export class AppPageXXX extends TiniComponent {
 
   readonly metadata: PageMetadata = {
@@ -54,12 +54,12 @@ export class AppPageXXX extends TiniComponent {
 For pages with data comes from the server, we can access the meta instance and set page metadata accordingly.
 
 ```ts
-import {UseMeta, Meta} from '@tinijs/meta';
+import {useMeta, Meta} from '@tinijs/meta';
 
-@Page({})
+@page({})
 export class AppPageXXX extends TiniComponent {
 
-  @UseMeta() readonly meta!: Meta;
+  @useMeta() readonly meta!: Meta;
 
   async onInit() {
     this.post = await fetchPost();

--- a/apps/tinijs.dev/content/module-posts/201 - pwa/index.md
+++ b/apps/tinijs.dev/content/module-posts/201 - pwa/index.md
@@ -70,11 +70,11 @@ addEventListener('message', event => {
 - Communicate with the Service Worker
 
 ```ts
-import {UseSW, type SW} from '@tinijs/pwa';
+import {useSW, type SW} from '@tinijs/pwa';
 
-@Page({})
+@page({})
 export class AppPageXXX extends TiniComponent {
-  @UseSW() readonly sw!: SW;
+  @useSW() readonly sw!: SW;
 
   async onReady() {
     const result = await this.sw.messageSW({type: 'endpoint-1'});

--- a/apps/tinijs.dev/content/toolbox-posts/101 - get-started/index.md
+++ b/apps/tinijs.dev/content/toolbox-posts/101 - get-started/index.md
@@ -41,19 +41,19 @@ TiniJS provides a dependency injection mechanism that allows you to lazy load an
 
 ```ts
 // provide dependencies in app.ts
-@App({
+@app({
   providers = {
     fetchService: () => import('@tinijs/toolbox/fetch/service.js');
   }
 });
 
 // later, inject dependencies elsewhere
-import {Inject} from '@tinijs/core';
+import {inject} from '@tinijs/core';
 import type {FetchService} from '@tinijs/toolbox/fetch';
 
 class XXX {
 
-  @Inject() fetchService!: FetchService;
+  @inject() fetchService!: FetchService;
 
   async onInit() {
     const result = await this.fetchService.get('...');

--- a/apps/tinijs.dev/content/toolbox-posts/202 - common-services/index.md
+++ b/apps/tinijs.dev/content/toolbox-posts/202 - common-services/index.md
@@ -29,6 +29,6 @@ const providers = {
 // inject
 import type {CommonService} from '@tinijs/toolbox/common';
 class XXX {
-  @Inject() commonService!: CommonService;
+  @inject() commonService!: CommonService;
 }
 ```

--- a/apps/tinijs.dev/content/toolbox-posts/302 - app-services/index.md
+++ b/apps/tinijs.dev/content/toolbox-posts/302 - app-services/index.md
@@ -29,6 +29,6 @@ const providers = {
 // inject
 import type {AppService} from '@tinijs/toolbox/app';
 class XXX {
-  @Inject() appService!: AppService;
+  @inject() appService!: AppService;
 }
 ```

--- a/apps/tinijs.dev/content/toolbox-posts/402 - fetch-services/index.md
+++ b/apps/tinijs.dev/content/toolbox-posts/402 - fetch-services/index.md
@@ -29,6 +29,6 @@ const providers = {
 // inject
 import type {FetchService} from '@tinijs/toolbox/fetch';
 class XXX {
-  @Inject() fetchService!: FetchService;
+  @inject() fetchService!: FetchService;
 }
 ```

--- a/apps/tinijs.dev/content/toolbox-posts/502 - localstorage-services/index.md
+++ b/apps/tinijs.dev/content/toolbox-posts/502 - localstorage-services/index.md
@@ -29,6 +29,6 @@ const providers = {
 // inject
 import type {LocalstorageService} from '@tinijs/toolbox/localstorage';
 class XXX {
-  @Inject() localstorageService!: LocalstorageService;
+  @inject() localstorageService!: LocalstorageService;
 }
 ```

--- a/apps/tinijs.dev/content/ui-posts/102 - playground/index.ts
+++ b/apps/tinijs.dev/content/ui-posts/102 - playground/index.ts
@@ -17,12 +17,12 @@ import {TiniIconComponent} from '../../../app/ui/components/icon.js';
 import {TiniBadgeComponent} from '../../../app/ui/components/badge.js';
 import {TiniButtonComponent} from '../../../app/ui/components/button.js';
 
-import {Component, TiniComponent} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 const ICON_SRC =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' viewBox='0 0 16 16'%3E%3Cpath fill='%23000' fill-rule='evenodd' d='M8 1.314C12.438-3.248 23.534 4.735 8 15C-7.534 4.736 3.562-3.248 8 1.314'/%3E%3C/svg%3E";
 
-@Component({
+@component({
   components: [
     AppThemeSelectorComponent,
     TiniBoxComponent,

--- a/apps/tinijs.dev/content/ui-posts/201 - design-tokens/index.ts
+++ b/apps/tinijs.dev/content/ui-posts/201 - design-tokens/index.ts
@@ -1,11 +1,11 @@
 import {html, css, nothing} from 'lit';
+import {property} from 'lit/decorators/property.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {styleMap} from 'lit/directives/style-map.js';
 
 import {
-  Component,
+  component,
   TiniComponent,
-  Input,
   Colors,
   Gradients,
   Fonts,
@@ -25,14 +25,14 @@ import {
 
 const computedStyle = getComputedStyle(document.documentElement);
 
-@Component()
+@component()
 export class ContentUIPostTokenComponent
   extends TiniComponent
   implements OnCreate
 {
   static readonly defaultTagName = 'content-ui-post-token';
 
-  @Input() block!: string;
+  @property() block!: string;
 
   onCreate() {
     if (!this.block) throw new Error('block is required');

--- a/apps/tinijs.dev/content/ui-posts/401 - box/index.ts
+++ b/apps/tinijs.dev/content/ui-posts/401 - box/index.ts
@@ -1,6 +1,7 @@
 import {html, css, nothing} from 'lit';
+import {property} from 'lit/decorators/property.js';
 
-import {Component, TiniComponent, Input} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {UIConsumerTargets} from '../../../app/consts/common.js';
 
@@ -13,7 +14,7 @@ import {TiniButtonComponent} from '../../../app/ui/components/button.js';
 import {AppComponentEditorComponent} from '../../../app/components/component-editor/index.js';
 import {AppComponentUsageComponent} from '../../../app/components/component-usage.js';
 
-@Component({
+@component({
   components: [
     TiniBoxComponent,
     TiniFlexComponent,
@@ -27,7 +28,7 @@ import {AppComponentUsageComponent} from '../../../app/components/component-usag
 export class ContentUIPostBoxComponent extends TiniComponent {
   static readonly defaultTagName = 'content-ui-post-box';
 
-  @Input() block!: string;
+  @property() block!: string;
 
   onCreate() {
     if (!this.block) throw new Error('block is required');

--- a/apps/tinijs.dev/content/ui-posts/402 - flex/index.ts
+++ b/apps/tinijs.dev/content/ui-posts/402 - flex/index.ts
@@ -1,16 +1,17 @@
 import {html, css, nothing} from 'lit';
+import {property} from 'lit/decorators/property.js';
 
-import {Component, TiniComponent, Input} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {AppComponentEditorComponent} from '../../../app/components/component-editor/index.js';
 
-@Component({
+@component({
   components: [AppComponentEditorComponent],
 })
 export class ContentUIPostFlexComponent extends TiniComponent {
   static readonly defaultTagName = 'content-ui-post-flex';
 
-  @Input() block!: string;
+  @property() block!: string;
 
   onCreate() {
     if (!this.block) throw new Error('block is required');

--- a/apps/tinijs.dev/content/ui-posts/403 - grid/index.ts
+++ b/apps/tinijs.dev/content/ui-posts/403 - grid/index.ts
@@ -1,16 +1,17 @@
 import {html, css, nothing} from 'lit';
+import {property} from 'lit/decorators/property.js';
 
-import {Component, TiniComponent, Input} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {AppComponentEditorComponent} from '../../../app/components/component-editor/index.js';
 
-@Component({
+@component({
   components: [AppComponentEditorComponent],
 })
 export class ContentUIPostGridComponent extends TiniComponent {
   static readonly defaultTagName = 'content-ui-post-grid';
 
-  @Input() block!: string;
+  @property() block!: string;
 
   onCreate() {
     if (!this.block) throw new Error('block is required');

--- a/apps/tinijs.dev/content/ui-posts/404 - container/index.ts
+++ b/apps/tinijs.dev/content/ui-posts/404 - container/index.ts
@@ -1,16 +1,17 @@
 import {html, css, nothing} from 'lit';
+import {property} from 'lit/decorators/property.js';
 
-import {Component, TiniComponent, Input} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {AppComponentEditorComponent} from '../../../app/components/component-editor/index.js';
 
-@Component({
+@component({
   components: [AppComponentEditorComponent],
 })
 export class ContentUIPostContainerComponent extends TiniComponent {
   static readonly defaultTagName = 'content-ui-post-container';
 
-  @Input() block!: string;
+  @property() block!: string;
 
   onCreate() {
     if (!this.block) throw new Error('block is required');

--- a/apps/tinijs.dev/content/ui-posts/504001 - dialog/index.ts
+++ b/apps/tinijs.dev/content/ui-posts/504001 - dialog/index.ts
@@ -1,7 +1,8 @@
 import {html, css, nothing} from 'lit';
+import {property} from 'lit/decorators/property.js';
 import {ref, createRef} from 'lit/directives/ref.js';
 
-import {Component, TiniComponent, Input} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {UIConsumerTargets} from '../../../app/consts/common.js';
 
@@ -10,7 +11,7 @@ import {TiniButtonComponent} from '../../../app/ui/components/button.js';
 import {TiniCodeComponent} from '../../../app/ui/components/code.js';
 import {TiniDialogComponent} from '../../../app/ui/components/dialog.js';
 
-@Component({
+@component({
   components: [
     TiniButtonComponent,
     TiniCodeComponent,
@@ -21,7 +22,7 @@ import {TiniDialogComponent} from '../../../app/ui/components/dialog.js';
 export class ContentUIPostDialogComponent extends TiniComponent {
   static readonly defaultTagName = 'content-ui-post-dialog';
 
-  @Input() block!: string;
+  @property() block!: string;
 
   onCreate() {
     if (!this.block) throw new Error('block is required');

--- a/apps/tinijs.dev/content/ui-posts/513002 - modal/index.ts
+++ b/apps/tinijs.dev/content/ui-posts/513002 - modal/index.ts
@@ -1,12 +1,12 @@
 import {html, css} from 'lit';
 import {ref, createRef} from 'lit/directives/ref.js';
 
-import {Component, TiniComponent} from '@tinijs/core';
+import {component, TiniComponent} from '@tinijs/core';
 
 import {TiniButtonComponent} from '../../../app/ui/components/button.js';
 import {TiniModalComponent} from '../../../app/ui/components/modal.js';
 
-@Component({
+@component({
   components: [TiniButtonComponent, TiniModalComponent],
 })
 export class ContentUIPostModalComponent extends TiniComponent {

--- a/packages/cli/cli/utils/generate.ts
+++ b/packages/cli/cli/utils/generate.ts
@@ -254,9 +254,9 @@ export default ${className};\n`;
 function getLayoutMainContent({className, tagName}: Names) {
   return `import {html, css} from 'lit';
 
-import {Layout, TiniComponent} from '@tinijs/core';
+import {layout, TiniComponent} from '@tinijs/core';
 
-@Layout({
+@layout({
   name: '${tagName}',
 })
 export class ${className} extends TiniComponent {
@@ -272,9 +272,9 @@ export class ${className} extends TiniComponent {
 function getPageMainContent({className, tagName}: Names) {
   return `import {html, css} from 'lit';
 
-import {Page, TiniComponent} from '@tinijs/core';
+import {page, TiniComponent} from '@tinijs/core';
 
-@Page({
+@page({
   name: '${tagName}',
 })
 export class ${className} extends TiniComponent {
@@ -289,23 +289,24 @@ export class ${className} extends TiniComponent {
 
 function getComponentMainContent({className, tagName}: Names) {
   return `import {html, css} from 'lit';
+import {property} from 'lit/decorators/property.js';
 
-import {Component, TiniComponent, Prop, Event, type EventEmitter, type OnCreate} from '@tinijs/core';
+import {component, event, TiniComponent, type EventEmitter, type OnCreate} from '@tinijs/core';
 
-@Component()
+@component()
 export class ${className} extends TiniComponent implements OnCreate {
   static readonly defaultTagName = '${tagName}';
 
-  @Prop() prop?: string;
+  @property() prop?: string;
 
-  @Event() event!: EventEmitter<any>;
+  @event() evt!: EventEmitter<any>;
 
   onCreate() {
     // element connected
   }
 
   emitEvent() {
-    this.event.emit('any payload');
+    this.evt.emit('any payload');
   }
 
   protected render() {

--- a/packages/core/lib/consts/error.ts
+++ b/packages/core/lib/consts/error.ts
@@ -1,8 +1,8 @@
 export const NO_APP_ERROR = new Error(
-  'No TiniJS app available, please init via @App() decorator first.'
+  'No TiniJS app available, please init via @app() decorator first.'
 );
 export const DUPLICATED_APP_ERROR = new Error(
-  'A TiniJS app is already available, you must init @App() only once.'
+  'A TiniJS app is already available, you must init @app() only once.'
 );
 
 export const NO_REGISTER_ERROR = (id: string) =>

--- a/packages/core/lib/decorators/app.ts
+++ b/packages/core/lib/decorators/app.ts
@@ -53,7 +53,7 @@ Please provide them in 'app/providers.ts' or correcting its order:
   }
 }
 
-export function App(options: AppOptions = {}) {
+export function app(options: AppOptions = {}) {
   return function (target: any) {
     // register the exit of the app splashscreen
     if (options.splashscreen) {

--- a/packages/core/lib/decorators/component.ts
+++ b/packages/core/lib/decorators/component.ts
@@ -2,7 +2,7 @@ import {customElement} from 'lit/decorators/custom-element.js';
 
 import {ComponentTypes, type ComponentOptions} from '../classes/component.js';
 
-export function Component(options: ComponentOptions = {}) {
+export function component(options: ComponentOptions = {}) {
   return function (target: any) {
     target.componentType = options.type || ComponentTypes.Component;
     target.components = options.components;

--- a/packages/core/lib/decorators/event.ts
+++ b/packages/core/lib/decorators/event.ts
@@ -17,7 +17,7 @@ export class EventEmitter<Payload> {
   }
 }
 
-export function Event(options?: EventOptions<unknown>) {
+export function event(options?: EventOptions<unknown>) {
   return function (prototype: any, propertyName: string) {
     const emitterKey = Symbol();
     Object.defineProperty(prototype, propertyName, {
@@ -31,5 +31,3 @@ export function Event(options?: EventOptions<unknown>) {
     });
   };
 }
-
-export const Output = Event;

--- a/packages/core/lib/decorators/inject.ts
+++ b/packages/core/lib/decorators/inject.ts
@@ -2,7 +2,7 @@ import {NO_REGISTER_ERROR} from '../consts/error.js';
 
 import {getDIRegistry} from '../utils/di.js';
 
-export function Inject(id?: string) {
+export function inject(id?: string) {
   return function (prototype: any, propertyName: string) {
     const depId = (id || propertyName) as string;
     const dependencyRegistry = getDIRegistry();
@@ -40,6 +40,6 @@ export function Inject(id?: string) {
   };
 }
 
-export function Vendor(id?: string) {
-  return Inject(id);
+export function vendor(id?: string) {
+  return inject(id);
 }

--- a/packages/core/lib/decorators/layout.ts
+++ b/packages/core/lib/decorators/layout.ts
@@ -1,7 +1,7 @@
 import {ComponentTypes, type ComponentOptions} from '../classes/component.js';
 
-import {Component} from './component.js';
+import {component} from './component.js';
 
-export function Layout(options?: Omit<ComponentOptions, 'type'>) {
-  return Component({...options, type: ComponentTypes.Layout});
+export function layout(options?: Omit<ComponentOptions, 'type'>) {
+  return component({...options, type: ComponentTypes.Layout});
 }

--- a/packages/core/lib/decorators/page.ts
+++ b/packages/core/lib/decorators/page.ts
@@ -1,7 +1,7 @@
 import {ComponentTypes, type ComponentOptions} from '../classes/component.js';
 
-import {Component} from './component.js';
+import {component} from './component.js';
 
-export function Page(options?: Omit<ComponentOptions, 'type'>) {
-  return Component({...options, type: ComponentTypes.Page});
+export function page(options?: Omit<ComponentOptions, 'type'>) {
+  return component({...options, type: ComponentTypes.Page});
 }

--- a/packages/core/lib/decorators/property.ts
+++ b/packages/core/lib/decorators/property.ts
@@ -1,7 +1,0 @@
-import {property} from 'lit/decorators/property.js';
-import {state} from 'lit/decorators/state.js';
-
-export const Prop = property;
-export const Input = property;
-
-export const Reactive = state;

--- a/packages/core/lib/decorators/use.ts
+++ b/packages/core/lib/decorators/use.ts
@@ -4,7 +4,7 @@ import {getOptions, getApp} from '../utils/app.js';
 import {getConfig} from '../utils/config.js';
 import {getSplashscreen} from '../utils/splashscreen.js';
 
-export function UseApp() {
+export function useApp() {
   return function (prototype: any, propertyName: string) {
     Object.defineProperty(prototype, propertyName, {
       get: () => getApp(),
@@ -12,7 +12,7 @@ export function UseApp() {
   };
 }
 
-export function UseOptions() {
+export function useOptions() {
   return function (prototype: any, propertyName: string) {
     Object.defineProperty(prototype, propertyName, {
       get: () => getOptions(),
@@ -20,7 +20,7 @@ export function UseOptions() {
   };
 }
 
-export function UseConfig() {
+export function useConfig() {
   return function (prototype: any, propertyName: string) {
     Object.defineProperty(prototype, propertyName, {
       get: () => getConfig(),
@@ -28,7 +28,7 @@ export function UseConfig() {
   };
 }
 
-export function UseSplashscreen() {
+export function useSplashscreen() {
   return function (prototype: any, propertyName: string) {
     Object.defineProperty(prototype, propertyName, {
       get: () => getSplashscreen(),
@@ -36,7 +36,7 @@ export function UseSplashscreen() {
   };
 }
 
-export function UseUI() {
+export function useUI() {
   return function (prototype: any, propertyName: string) {
     Object.defineProperty(prototype, propertyName, {
       get: () => getUI(),

--- a/packages/core/lib/decorators/watch.ts
+++ b/packages/core/lib/decorators/watch.ts
@@ -28,7 +28,7 @@ export class Watching implements ReactiveController {
   }
 }
 
-export function Watchable(handlerName?: string, skipInitial?: boolean) {
+export function watchable(handlerName?: string, skipInitial?: boolean) {
   return function (prototype: any, propertyName: string) {
     const valueKey = `___${propertyName}`;
     const handlerKey = handlerName || `${propertyName}Changes`;
@@ -65,7 +65,7 @@ export function Watchable(handlerName?: string, skipInitial?: boolean) {
   };
 }
 
-export function Watch() {
+export function watch() {
   return function (prototype: any, propertyName: string) {
     const watcherKey = Symbol();
     Object.defineProperty(prototype, propertyName, {

--- a/packages/core/lib/public-api.ts
+++ b/packages/core/lib/public-api.ts
@@ -12,7 +12,6 @@ export * from './decorators/event.js';
 export * from './decorators/inject.js';
 export * from './decorators/layout.js';
 export * from './decorators/page.js';
-export * from './decorators/property.js';
 export * from './decorators/use.js';
 export * from './decorators/watch.js';
 

--- a/packages/meta/lib/decorators.ts
+++ b/packages/meta/lib/decorators.ts
@@ -1,6 +1,6 @@
 import {getMeta} from './methods.js';
 
-export function UseMeta() {
+export function useMeta() {
   return function (prototype: any, propertyName: string) {
     Object.defineProperty(prototype, propertyName, {
       get: () => getMeta(),

--- a/packages/pwa/lib/decorators.ts
+++ b/packages/pwa/lib/decorators.ts
@@ -1,6 +1,6 @@
 import {getSW} from './methods.js';
 
-export function UseSW() {
+export function useSW() {
   return function (prototype: any, propertyKey: string) {
     Object.defineProperty(prototype, propertyKey, {
       get: () => getSW(),

--- a/packages/router/lib/decorators.ts
+++ b/packages/router/lib/decorators.ts
@@ -2,12 +2,12 @@ import {
   getRouter,
   getActiveRoute,
   getParams,
-  getQuery,
-  getFragment,
+  getSearchParams,
+  getFragmentId,
   getNavIndicator,
 } from './methods.js';
 
-export function UseRouter() {
+export function useRouter() {
   return function (prototype: any, propertyName: string) {
     Object.defineProperty(prototype, propertyName, {
       get: () => getRouter(),
@@ -15,7 +15,7 @@ export function UseRouter() {
   };
 }
 
-export function UseRoute() {
+export function useRoute() {
   return function (prototype: any, propertyName: string) {
     Object.defineProperty(prototype, propertyName, {
       get: () => getActiveRoute(),
@@ -23,7 +23,7 @@ export function UseRoute() {
   };
 }
 
-export function UseParams() {
+export function useParams() {
   return function (prototype: any, propertyName: string) {
     Object.defineProperty(prototype, propertyName, {
       get: () => getParams(),
@@ -31,23 +31,23 @@ export function UseParams() {
   };
 }
 
-export function UseQuery() {
+export function useSearchParams() {
   return function (prototype: any, propertyName: string) {
     Object.defineProperty(prototype, propertyName, {
-      get: () => getQuery(),
+      get: () => getSearchParams(),
     });
   };
 }
 
-export function UseFragment() {
+export function useFragmentId() {
   return function (prototype: any, propertyName: string) {
     Object.defineProperty(prototype, propertyName, {
-      get: () => getFragment(),
+      get: () => getFragmentId(),
     });
   };
 }
 
-export function UseNavIndicator() {
+export function useNavIndicator() {
   return function (prototype: any, propertyName: string) {
     Object.defineProperty(prototype, propertyName, {
       get: () => getNavIndicator(),

--- a/packages/router/lib/methods.ts
+++ b/packages/router/lib/methods.ts
@@ -20,12 +20,12 @@ export function getParams() {
   return getRouter().getParams();
 }
 
-export function getQuery() {
-  return getRouter().getQuery();
+export function getSearchParams() {
+  return getRouter().getSearchParams();
 }
 
-export function getFragment() {
-  return getRouter().getFragment();
+export function getFragmentId() {
+  return getRouter().getFragmentId();
 }
 
 export function requestChange() {

--- a/packages/router/lib/router.ts
+++ b/packages/router/lib/router.ts
@@ -150,12 +150,12 @@ export class Router {
     return this.getActiveRoute()?.params || {};
   }
 
-  getQuery() {
-    return this.getActiveRoute()?.query || {};
+  getSearchParams() {
+    return this.getActiveRoute()?.searchParams || {};
   }
 
-  getFragment() {
-    return this.getActiveRoute()?.fragment || '';
+  getFragmentId() {
+    return this.getActiveRoute()?.fragmentId || '';
   }
 
   match(url: URL): MatchResult {
@@ -216,22 +216,22 @@ export class Router {
     } = !matchedRoutePath || !matchedExecResult
       ? ({} as ReturnType<Router['extractParams']>)
       : this.extractParams(matchedRoutePath, matchedExecResult);
-    const query = {} as Record<string, any>;
+    const searchParams = {} as Record<string, any>;
     url.searchParams.forEach((value, key) => {
       if (!/\[\]$/.test(key)) {
-        query[key] = value;
+        searchParams[key] = value;
       } else {
         key = key.slice(0, -2);
-        if (!query[key]) {
-          query[key] = [value];
+        if (!searchParams[key]) {
+          searchParams[key] = [value];
         } else {
-          query[key] = Array.isArray(query[key])
-            ? query[key].concat(value)
-            : [query[key], value];
+          searchParams[key] = Array.isArray(searchParams[key])
+            ? searchParams[key].concat(value)
+            : [searchParams[key], value];
         }
       }
     });
-    const fragment = url.hash.replace(/^#/, '');
+    const fragmentId = url.hash.replace(/^#/, '');
     const result: MatchResult = {
       url,
       path,
@@ -239,8 +239,8 @@ export class Router {
       regexp,
       keys,
       params,
-      query,
-      fragment,
+      searchParams,
+      fragmentId,
       layoutRoute: matched?.layout,
       pageRoute: matched?.page,
     };

--- a/packages/router/lib/types.ts
+++ b/packages/router/lib/types.ts
@@ -48,8 +48,8 @@ export interface MatchResult {
   regexp?: RegExp;
   keys?: Key[];
   params?: Record<string, any>;
-  query?: Record<string, any>;
-  fragment?: string;
+  searchParams?: Record<string, any>;
+  fragmentId?: string;
   pageRoute?: Route;
   layoutRoute?: Route;
 }

--- a/packages/store/lib/decorators.ts
+++ b/packages/store/lib/decorators.ts
@@ -1,6 +1,6 @@
 import type {Store} from './types.js';
 
-export function Subscribe<States>(
+export function globalState<States>(
   store: Store<States>,
   stateKey?: keyof States | null,
   reactive = true

--- a/packages/ui/lib/classes/layout.ts
+++ b/packages/ui/lib/classes/layout.ts
@@ -1,5 +1,5 @@
 import {html} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {
   TiniElement,
   ALL_COLORS,

--- a/packages/ui/ui/components/badge.ts
+++ b/packages/ui/ui/components/badge.ts
@@ -1,5 +1,5 @@
 import {html, css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {
   TiniElement,
   ElementParts,

--- a/packages/ui/ui/components/breadcrumbs.ts
+++ b/packages/ui/ui/components/breadcrumbs.ts
@@ -5,7 +5,7 @@ import {
   type CSSResult,
   type TemplateResult,
 } from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {
   TiniElement,

--- a/packages/ui/ui/components/button.ts
+++ b/packages/ui/ui/components/button.ts
@@ -1,5 +1,5 @@
 import {html, css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 import {
   TiniElement,

--- a/packages/ui/ui/components/card.ts
+++ b/packages/ui/ui/components/card.ts
@@ -1,5 +1,5 @@
 import {html, css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {TiniElement, ElementParts, createStyleBuilder} from '@tinijs/core';
 
 export enum CardParts {

--- a/packages/ui/ui/components/checkboxes.ts
+++ b/packages/ui/ui/components/checkboxes.ts
@@ -1,5 +1,5 @@
 import {html, nothing, css, type PropertyValues, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 import {

--- a/packages/ui/ui/components/code.ts
+++ b/packages/ui/ui/components/code.ts
@@ -1,5 +1,5 @@
 import {html, css, type PropertyValues, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {classMap, type ClassInfo} from 'lit/directives/class-map.js';
 import {ref, createRef} from 'lit/directives/ref.js';
 

--- a/packages/ui/ui/components/dialog.ts
+++ b/packages/ui/ui/components/dialog.ts
@@ -1,5 +1,5 @@
 import {html, nothing, css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {ref, createRef} from 'lit/directives/ref.js';
 import {
   TiniElement,

--- a/packages/ui/ui/components/embed.ts
+++ b/packages/ui/ui/components/embed.ts
@@ -1,5 +1,5 @@
 import {html, css, type PropertyValues, CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {styleMap, type StyleInfo} from 'lit/directives/style-map.js';
 
 import {TiniElement, ElementParts, createStyleBuilder} from '@tinijs/core';

--- a/packages/ui/ui/components/heading.ts
+++ b/packages/ui/ui/components/heading.ts
@@ -1,5 +1,5 @@
 import {css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {html, unsafeStatic} from 'lit/static-html.js';
 
 import {

--- a/packages/ui/ui/components/icon.ts
+++ b/packages/ui/ui/components/icon.ts
@@ -1,5 +1,5 @@
 import {html, css, type PropertyValues, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {
   TiniElement,
   ElementParts,

--- a/packages/ui/ui/components/image.ts
+++ b/packages/ui/ui/components/image.ts
@@ -1,5 +1,5 @@
 import {html, css, type PropertyValues, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 
 import {

--- a/packages/ui/ui/components/input.ts
+++ b/packages/ui/ui/components/input.ts
@@ -1,5 +1,5 @@
 import {html, nothing, css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 import {
   TiniElement,

--- a/packages/ui/ui/components/label.ts
+++ b/packages/ui/ui/components/label.ts
@@ -1,5 +1,5 @@
 import {html, css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {
   TiniElement,
   ElementParts,

--- a/packages/ui/ui/components/link.ts
+++ b/packages/ui/ui/components/link.ts
@@ -1,5 +1,5 @@
 import {html, css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 import {ref, createRef} from 'lit/directives/ref.js';
 import {

--- a/packages/ui/ui/components/message.ts
+++ b/packages/ui/ui/components/message.ts
@@ -1,5 +1,5 @@
 import {html, css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {
   TiniElement,
   ElementParts,

--- a/packages/ui/ui/components/modal.ts
+++ b/packages/ui/ui/components/modal.ts
@@ -1,5 +1,5 @@
 import {html, css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {ref, createRef} from 'lit/directives/ref.js';
 import {
   TiniElement,

--- a/packages/ui/ui/components/pagination.ts
+++ b/packages/ui/ui/components/pagination.ts
@@ -1,5 +1,5 @@
 import {html, css, type PropertyValues, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {
   TiniElement,

--- a/packages/ui/ui/components/radios.ts
+++ b/packages/ui/ui/components/radios.ts
@@ -1,5 +1,5 @@
 import {html, nothing, css, type PropertyValues, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {
   TiniElement,

--- a/packages/ui/ui/components/select.ts
+++ b/packages/ui/ui/components/select.ts
@@ -1,5 +1,5 @@
 import {html, nothing, css, type PropertyValues, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 import {
   TiniElement,

--- a/packages/ui/ui/components/skeleton.ts
+++ b/packages/ui/ui/components/skeleton.ts
@@ -1,5 +1,5 @@
 import {html, css, type PropertyValues, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 
 import {
   TiniElement,

--- a/packages/ui/ui/components/spinner.ts
+++ b/packages/ui/ui/components/spinner.ts
@@ -1,5 +1,5 @@
 import {html, css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {
   TiniElement,
   ElementParts,

--- a/packages/ui/ui/components/switch.ts
+++ b/packages/ui/ui/components/switch.ts
@@ -1,5 +1,5 @@
 import {html, nothing, css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 import {
   TiniElement,

--- a/packages/ui/ui/components/table.ts
+++ b/packages/ui/ui/components/table.ts
@@ -5,7 +5,7 @@ import {
   type TemplateResult,
   type CSSResult,
 } from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 
 import {TiniElement, ElementParts, createStyleBuilder} from '@tinijs/core';

--- a/packages/ui/ui/components/text.ts
+++ b/packages/ui/ui/components/text.ts
@@ -1,5 +1,5 @@
 import {html, css, unsafeCSS, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {
   TiniElement,
   ElementParts,

--- a/packages/ui/ui/components/textarea.ts
+++ b/packages/ui/ui/components/textarea.ts
@@ -1,5 +1,5 @@
 import {html, nothing, css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 import {ifDefined} from 'lit/directives/if-defined.js';
 import {
   TiniElement,

--- a/packages/ui/ui/components/xxx.txt
+++ b/packages/ui/ui/components/xxx.txt
@@ -1,5 +1,5 @@
 import {html, css, type CSSResult} from 'lit';
-import {property} from 'lit/decorators.js';
+import {property} from 'lit/decorators/property.js';
 
 import {TiniElement, ElementParts, createStyleBuilder, Colors, Sizes} from '@tinijs/core';
 


### PR DESCRIPTION
Previously, I think of providing different syntax for fellow devs who may come from different frameworks, started with Angular-alike syntax, then adding composable syntax for Vue devs, etc.

Due to the limit of dev effort, for now, I remove the Angular-syntax in order to provide a more neutral syntax adhere to the styles of Lit, includes:
- Use lowercase for decorators
- Remove proxied decorators (Input, Output, ...)